### PR TITLE
Update README.md - Fix typo in link to LionWeb GitHub repo base.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # Freon, previously know as ProjectIt
 Projectional Editor for the Web. The current release (version 0.6.0-beta.0) can be found on npm.
 
-This beta release supports [LIonWeb](https://github.com/LIonWeb-org) (de)serialization. 
-As LIonWeb is in motion, excpect this release to change according to LIonWeb changes before it becomes final. 
+This beta release supports [LionWeb](https://github.com/LionWeb-io) (de)serialization. 
+As LionWeb is in motion, excpect this release to change according to LionWeb changes before it becomes final. 
 
 ## What is Freon
 


### PR DESCRIPTION
Fix typo in link to LionWeb GitHub repo base.

I also aligned the capitalisation of LIonWeb to LionWeb, which seemed to be consistent with what I saw their documentation.