### PR TITLE
Replace jest by vitest in test package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "ts-node": "^10.9.2",
     "tslib": "^2.6.3",
     "typescript": "5.4.5",
-    "typescript-svelte-plugin": "0.3.38"
+    "typescript-svelte-plugin": "0.3.38",
+    "@vitest/ui": "^2.0.3"
+
   },
   "workspaces": [
     "packages/core",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -55,7 +55,11 @@
     "clean-undo-tester": "bash ../../scripts/freon-test-dev.sh clean-it -d src/UndoTester/defs -o src/UndoTester",
     "clean-vehicles": "bash ../../scripts/freon-test-dev.sh clean-it -f -d src/vehicles/defs -o src/vehicles",
     "clean-all-projects": "npm run clean-demo && npm run clean-octopus && npm run clean-parser-conc && npm run clean-basic-props && npm run clean-parsergen && npm run clean-imports && npm run clean-defaultscoper && npm run clean-definedscoper && npm run clean-langconstr && npm run clean-noparser && npm run clean-prim-gen && npm run clean-testproject && npm run clean-typer-test8 && npm run clean-vehicles",
-    "test": "jest"
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^2.0.3",
+    "@vitest/ui": "^2.0.3"
   },
   "dependencies": {
     "@freon4dsl/core": "0.7.0-beta",

--- a/packages/test/src/UndoTester/__tests__/readUndoFiles.test.ts
+++ b/packages/test/src/UndoTester/__tests__/readUndoFiles.test.ts
@@ -2,6 +2,7 @@ import { UndoModel, UndoPart, UndoUnit } from "../language/gen";
 import { UndoModelEnvironment } from "../config/gen/UndoModelEnvironment";
 import { FileHandler } from "../../utils/FileHandler";
 import { FreUndoManager } from "@freon4dsl/core";
+import { describe, it, expect} from "vitest"
 
 const handler = new FileHandler();
 const reader = UndoModelEnvironment.getInstance().reader;

--- a/packages/test/src/demo/__tests__/Serializer.test.ts
+++ b/packages/test/src/demo/__tests__/Serializer.test.ts
@@ -2,14 +2,15 @@ import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { DemoEntity, DemoFunction, DemoModel } from "../language/gen";
 import { FreModelSerializer } from "@freon4dsl/core";
 import { JsonModelCreator } from "./JsonModelCreator";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("Checking Serializer on Demo", () => {
     DemoEnvironment.getInstance();
     let initialModel: DemoModel = new JsonModelCreator().model;
 
-    beforeEach(done => {
-        done();
-    });
+    // beforeEach(done => {
+    //     done();
+    // });
 
     test("model-to-json, followed by json-to-model should result in same model", () => {
         expect(initialModel.name).not.toBeNull();

--- a/packages/test/src/demo/__tests__/__snapshots__/checkUnparser.test.ts.snap
+++ b/packages/test/src/demo/__tests__/__snapshots__/checkUnparser.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Testing Unparser Unparse DemoModel Instance 'determine(AAP : TEST1) : TEST2 = "Hello Demo" + "Goodbye"' 1`] = `
+exports[`Testing Unparser > Unparse DemoModel Instance > 'determine(AAP : TEST1) : TEST2 = "Hello Demo" + "Goodbye"' 1`] = `
 "DemoFunction determine {
     expression ' "Hello Demo" ' + ' "Goodbye" '
     parameters
@@ -9,7 +9,7 @@ exports[`Testing Unparser Unparse DemoModel Instance 'determine(AAP : TEST1) : T
 }"
 `;
 
-exports[`Testing Unparser Unparse DemoModel Instance complete example model with simple attribute types 1`] = `
+exports[`Testing Unparser > Unparse DemoModel Instance > complete example model with simple attribute types 1`] = `
 "model DemoModel_with_inheritance {
 main:
 types:
@@ -132,7 +132,7 @@ model wide functions:
 }"
 `;
 
-exports[`Testing Unparser Unparse DemoModel Instance complete example model with simple attribute types 2`] = `
+exports[`Testing Unparser > Unparse DemoModel Instance > complete example model with simple attribute types 2`] = `
 "model CorrectUnit {
 main:
 types:

--- a/packages/test/src/demo/__tests__/checkModelCreator.test.ts
+++ b/packages/test/src/demo/__tests__/checkModelCreator.test.ts
@@ -1,14 +1,15 @@
 import { FreNode } from "@freon4dsl/core";
 import { DemoModel, DemoFunction, DemoEntity } from "../language/gen";
 import { DemoModelCreator } from "./DemoModelCreator";
+import { describe, test, expect } from "vitest"
 
 describe("Demo Model", () => {
     describe("Checking DemoModel incorrect instance", () => {
         let model: DemoModel = new DemoModelCreator().createIncorrectModel().models[0];
 
-        beforeEach(done => {
-            done();
-        });
+        // beforeEach(done => {
+        //     done();
+        // });
 
         test("model name should be set", () => {
             expect(model.name).not.toBeNull();

--- a/packages/test/src/demo/__tests__/checkParser.test.ts
+++ b/packages/test/src/demo/__tests__/checkParser.test.ts
@@ -2,12 +2,13 @@ import { DemoModelCreator } from "./DemoModelCreator";
 import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { Demo, DemoModel } from "../language/gen";
 import { FileHandler } from "../../utils/FileHandler";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("Testing Parser", () => {
 
-    beforeEach(done => {
+    beforeEach(() => {
         DemoEnvironment.getInstance();
-        done();
+        // done();
     });
 
     test("complete example model unparsed and parsed again", () => {

--- a/packages/test/src/demo/__tests__/checkScoper.test.ts
+++ b/packages/test/src/demo/__tests__/checkScoper.test.ts
@@ -2,15 +2,15 @@ import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { DemoScoper } from "../scoper/gen";
 import { DemoModel, DemoFunction, Demo } from "../language/gen";
 import { DemoModelCreator } from "./DemoModelCreator";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("testing Scoper", () => {
     describe("Scoper.getVisibleElements from DemoModel Instance", () => {
         let model: Demo = new DemoModelCreator().createIncorrectModel();
         let scoper = new DemoScoper();
 
-        beforeEach(done => {
+        beforeEach(() => {
             DemoEnvironment.getInstance();
-            done();
         });
 
         test("visible elements in model and unit", () => {

--- a/packages/test/src/demo/__tests__/checkScoperAlternativeScope.test.ts
+++ b/packages/test/src/demo/__tests__/checkScoperAlternativeScope.test.ts
@@ -2,6 +2,7 @@ import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { DemoScoper } from "../scoper/gen";
 import { AppliedFeature, DemoAttributeRef, Demo } from "../language/gen";
 import { DemoModelCreator } from "./DemoModelCreator";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("testing Alternative Scopes", () => {
     describe("testing IsInScope", () => {
@@ -12,9 +13,8 @@ describe("testing Alternative Scopes", () => {
         // where 'Variable1.attrFromPerson' is of type Company
         let scoper = new DemoScoper();
 
-        beforeEach(done => {
+        beforeEach(() => {
             DemoEnvironment.getInstance();
-            done();
         });
 
         test("isInscope 'name' of 'Variable1.attrFromPerson', Variable1: Person", () => {

--- a/packages/test/src/demo/__tests__/checkScoperInheritance.test.ts
+++ b/packages/test/src/demo/__tests__/checkScoperInheritance.test.ts
@@ -2,15 +2,15 @@ import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { DemoScoper } from "../scoper/gen";
 import { DemoEntity, Demo } from "../language/gen";
 import { DemoModelCreator } from "./DemoModelCreator";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("testing Scoper", () => {
     let modelCreator = new DemoModelCreator();
     let inheritanceModel: Demo = modelCreator.createInheritanceModel();
     let scoper = new DemoScoper();
 
-    beforeEach(done => {
+    beforeEach(() => {
         DemoEnvironment.getInstance();
-        done();
     });
 
     // TODO make this two separate tests, that each run every time

--- a/packages/test/src/demo/__tests__/checkScoperModelUnits.test.ts
+++ b/packages/test/src/demo/__tests__/checkScoperModelUnits.test.ts
@@ -5,6 +5,7 @@ import { DemoModelCreator } from "./DemoModelCreator";
 import { DemoStdlib } from "../stdlib/gen/DemoStdlib";
 import { DemoUnitCreator } from "./DemoUnitCreator";
 import { DemoEnvironment } from "../config/gen/DemoEnvironment";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("testing Scoper on model units", () => {
 
@@ -13,9 +14,8 @@ describe("testing Scoper on model units", () => {
         let scoper = DemoEnvironment.getInstance().scoper;
         let stdlib = DemoStdlib.getInstance();
 
-        beforeEach(done => {
+        beforeEach(() => {
             DemoEnvironment.getInstance();
-            done();
         });
 
         test("visible elements in model", () => {

--- a/packages/test/src/demo/__tests__/checkStdLib.test.ts
+++ b/packages/test/src/demo/__tests__/checkStdLib.test.ts
@@ -2,6 +2,7 @@ import { FreLanguage } from "@freon4dsl/core";
 import { DemoAttributeType } from "../language/gen";
 import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { DemoStdlib } from "../stdlib/gen/DemoStdlib";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 // limited DemoAttributeType implements Type {
 //     name: string;
@@ -16,10 +17,9 @@ import { DemoStdlib } from "../stdlib/gen/DemoStdlib";
 
 describe("Checking stdlib for Demo", () => {
     let stdlib: DemoStdlib;
-    beforeEach(done => {
+    beforeEach(() => {
         DemoEnvironment.getInstance();
         stdlib = FreLanguage.getInstance().stdLib as DemoStdlib;
-        done();
     });
 
     test("all predefined instances of limited concepts should be found", () => {

--- a/packages/test/src/demo/__tests__/checkTyper.test.ts
+++ b/packages/test/src/demo/__tests__/checkTyper.test.ts
@@ -1,15 +1,12 @@
 import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { DemoModel, DemoAttributeType } from "../language/gen";
 import { DemoModelCreator } from "./DemoModelCreator";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("Testing Typer", () => {
     describe("Typer.isType on DemoModel Instance", () => {
         let model: DemoModel = new DemoModelCreator().createIncorrectModel().models[0];
         let typer = DemoEnvironment.getInstance().typer;
-
-        beforeEach(done => {
-            done();
-        });
 
         test("all entities should be types", () => {
             expect(typer.isType(model)).toBe(false);

--- a/packages/test/src/demo/__tests__/checkUnparser.test.ts
+++ b/packages/test/src/demo/__tests__/checkUnparser.test.ts
@@ -15,16 +15,13 @@ import { makeLiteralExp, MakeMultiplyExp, MakePlusExp } from "./HelperFunctions"
 import { DemoValidator } from "../validator/gen";
 import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 // import { FileHandler } from "../../utils/FileHandler";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 
 describe("Testing Unparser", () => {
     describe("Unparse DemoModel Instance", () => {
         // const model: DemoModel = new DemoModelCreator().createIncorrectModel().models[0];
         const unparser = DemoEnvironment.getInstance().writer;
-
-        beforeEach(done => {
-            done();
-        });
 
         test("3", () => {
             let result: string;

--- a/packages/test/src/demo/__tests__/checkValidator.test.ts
+++ b/packages/test/src/demo/__tests__/checkValidator.test.ts
@@ -15,14 +15,14 @@ import {
 import { DemoValidator } from "../validator/gen";
 import { DemoModelCreator } from "./DemoModelCreator";
 import { makeLiteralExp, MakeMultiplyExp, MakePlusExp } from "./HelperFunctions";
+import { describe, test, expect, beforeEach } from "vitest"
 
 describe("Testing Validator", () => {
     const model: Demo = new DemoModelCreator().createIncorrectModel();
     const validator = new DemoValidator();
 
-    beforeEach(done => {
+    beforeEach(() => {
         DemoEnvironment.getInstance();
-        done();
     });
 
     test("multiplication 3 * 10", () => {

--- a/packages/test/src/octopus-small/__tests__/readUmlFiles.test.ts
+++ b/packages/test/src/octopus-small/__tests__/readUmlFiles.test.ts
@@ -1,6 +1,7 @@
 import { OctopusModelEnvironment } from "../config/gen/OctopusModelEnvironment";
 import { compareReadAndWrittenUnits } from "../../utils/HelperFunctions";
 import { OctopusModel } from "../language/gen";
+import { describe, it, test } from "vitest"
 
 const writer = OctopusModelEnvironment.getInstance().writer;
 const reader = OctopusModelEnvironment.getInstance().reader;

--- a/packages/test/src/octopus-small/__tests__/searchElement.test.ts
+++ b/packages/test/src/octopus-small/__tests__/searchElement.test.ts
@@ -9,6 +9,7 @@ import {
     UmlPart
 } from "../language/gen";
 import { OctopusModelEnvironment } from "../config/gen/OctopusModelEnvironment";
+import { describe, test, expect } from "vitest"
 
 const writer = OctopusModelEnvironment.getInstance().writer;
 const reader = OctopusModelEnvironment.getInstance().reader;

--- a/packages/test/src/octopus-small/__tests__/searchNamedElement.test.ts
+++ b/packages/test/src/octopus-small/__tests__/searchNamedElement.test.ts
@@ -6,6 +6,7 @@ import {
     UmlPart
 } from "../language/gen";
 import { OctopusModelEnvironment } from "../config/gen/OctopusModelEnvironment";
+import { describe, test, expect } from "vitest"
 
 const writer = OctopusModelEnvironment.getInstance().writer;
 const reader = OctopusModelEnvironment.getInstance().reader;

--- a/packages/test/src/octopus-small/__tests__/searchString.test.ts
+++ b/packages/test/src/octopus-small/__tests__/searchString.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../language/gen";
 import { OctopusModelEnvironment } from "../config/gen/OctopusModelEnvironment";
 import { FileHandler } from "../../utils/FileHandler";
-
+import { describe, it, test, expect } from "vitest"
 
 const writer = OctopusModelEnvironment.getInstance().writer;
 const reader = OctopusModelEnvironment.getInstance().reader;

--- a/packages/test/src/parser-basic-concepts/__tests__/TryParser.test.ts
+++ b/packages/test/src/parser-basic-concepts/__tests__/TryParser.test.ts
@@ -2,6 +2,7 @@ import { FreUtils } from "@freon4dsl/core";
 import { FileHandler } from "../../utils/FileHandler";
 import { TestConceptsModelEnvironment } from "../config/gen/TestConceptsModelEnvironment";
 import { ExpressionTest, TestConceptsModel } from "../language/gen";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("Parser concepts of type", () => {
     const reader = TestConceptsModelEnvironment.getInstance().reader;

--- a/packages/test/src/parser-basic-concepts/__tests__/__snapshots__/TryParser.test.ts.snap
+++ b/packages/test/src/parser-basic-concepts/__tests__/__snapshots__/TryParser.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Parser concepts of type  Expression  1`] = `
+exports[`Parser concepts of type >  Expression  1`] = `
 ExpressionTest {
   "$$owner": TestConceptsModel {
     "$$owner": null,

--- a/packages/test/src/parser-basic-properties/__tests__/TryParser.test.ts
+++ b/packages/test/src/parser-basic-properties/__tests__/TryParser.test.ts
@@ -2,6 +2,7 @@ import { FreUtils } from "@freon4dsl/core";
 import { TestParserModelEnvironment } from "../config/gen/TestParserModelEnvironment";
 import { FileHandler } from "../../utils/FileHandler";
 import { LimitedTest, PartsTest, PrimitivesTest, RefsTest, PrimsWithKeywordTest, TestParserModel } from "../language/gen";
+import { describe, it, test, expect, beforeEach } from "vitest"
 
 describe("Parser properties of type", () => {
     const reader = TestParserModelEnvironment.getInstance().reader;

--- a/packages/test/src/parser-basic-properties/__tests__/__snapshots__/TryParser.test.ts.snap
+++ b/packages/test/src/parser-basic-properties/__tests__/__snapshots__/TryParser.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Parser properties of type  Limited Concept  1`] = `
+exports[`Parser properties of type >  Limited Concept  1`] = `
 LimitedTest {
   "$$owner": TestParserModel {
     "$$owner": null,
@@ -405,7 +405,7 @@ LimitedTest {
 }
 `;
 
-exports[`Parser properties of type  Part  1`] = `
+exports[`Parser properties of type >  Part  1`] = `
 PartsTest {
   "$$owner": TestParserModel {
     "$$owner": null,
@@ -568,7 +568,7 @@ PartsTest {
 }
 `;
 
-exports[`Parser properties of type  Part and Sub Parts  1`] = `
+exports[`Parser properties of type >  Part and Sub Parts  1`] = `
 PartsTest {
   "$$owner": TestParserModel {
     "$$owner": null,
@@ -1473,7 +1473,7 @@ PartsTest {
 }
 `;
 
-exports[`Parser properties of type  Part with Optionals present 1`] = `
+exports[`Parser properties of type >  Part with Optionals present 1`] = `
 PartsTest {
   "$$owner": TestParserModel {
     "$$owner": null,
@@ -1726,7 +1726,7 @@ PartsTest {
 }
 `;
 
-exports[`Parser properties of type  Primitive  1`] = `
+exports[`Parser properties of type >  Primitive  1`] = `
 PrimitivesTest {
   "$$owner": TestParserModel {
     "$$owner": null,
@@ -1913,7 +1913,7 @@ PrimitivesTest {
 }
 `;
 
-exports[`Parser properties of type  Primitive with Keyword projection  1`] = `
+exports[`Parser properties of type >  Primitive with Keyword projection  1`] = `
 PrimsWithKeywordTest {
   "$$owner": TestParserModel {
     "$$owner": null,
@@ -2038,7 +2038,7 @@ PrimsWithKeywordTest {
 }
 `;
 
-exports[`Parser properties of type  Ref  1`] = `
+exports[`Parser properties of type >  Ref  1`] = `
 RefsTest {
   "$$owner": TestParserModel {
     "$$owner": null,
@@ -2403,7 +2403,7 @@ RefsTest {
 }
 `;
 
-exports[`Parser properties of type  Ref with Optionals present 1`] = `
+exports[`Parser properties of type >  Ref with Optionals present 1`] = `
 RefsTest {
   "$$owner": TestParserModel {
     "$$owner": null,

--- a/packages/test/src/parser_gen/__tests__/TryParser.test.ts
+++ b/packages/test/src/parser_gen/__tests__/TryParser.test.ts
@@ -1,6 +1,7 @@
 import { Demo, DemoUnit } from "../language/gen";
 import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { FileHandler } from "../../utils/FileHandler";
+import { describe, test, expect } from "vitest"
 
 describe("Test the parser", () => {
     test( ": read two units and create a model", () => {

--- a/packages/test/src/parser_gen/__tests__/__snapshots__/TryParser.test.ts.snap
+++ b/packages/test/src/parser_gen/__tests__/__snapshots__/TryParser.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Test the parser : read two units and create a model 1`] = `
+exports[`Test the parser > : read two units and create a model 1`] = `
 "unit eenNaam {
 main: entity1 base anotherEntity,
                    andAnother,
@@ -21,7 +21,7 @@ unit wide functions:
 }"
 `;
 
-exports[`Test the parser : read two units and create a model 2`] = `
+exports[`Test the parser > : read two units and create a model 2`] = `
 "unit andereNaam {
 main: entity56 base anotherEntity,
                     andAnother,

--- a/packages/test/src/testCircularImports/__tests__/checkCircularImports.test.ts
+++ b/packages/test/src/testCircularImports/__tests__/checkCircularImports.test.ts
@@ -1,4 +1,5 @@
 import { ConceptA } from "../language/gen/internal";
+import { describe, test, expect } from "vitest"
 
 describe("Checking circular imports", () => {
     let concept1 = ConceptA.create({

--- a/packages/test/src/testDefaultScoper/__tests__/checkExtendedModels.test.ts
+++ b/packages/test/src/testDefaultScoper/__tests__/checkExtendedModels.test.ts
@@ -3,6 +3,7 @@ import { DSmodel, DSref, DSunit } from "../language/gen";
 import { SimpleModelCreator } from "./SimpleModelCreator";
 import { DSmodelEnvironment } from "../config/gen/DSmodelEnvironment";
 import { ExtendedModelCreator } from "./ExtendedModelCreator";
+import { describe, test, expect, beforeEach } from "vitest"
 
 function print(prefix: string, visibleNames: string[]) {
     let printable: string = "";
@@ -30,9 +31,8 @@ describe("Testing Default Scoper", () => {
     const scoper = environment.scoper;
     const unparser = environment.writer;
 
-    beforeEach(done => {
+    beforeEach(() => {
         DSmodelEnvironment.getInstance();
-        done();
     });
 
     test("validator messages in model with 1 unit of depth 3", () => {

--- a/packages/test/src/testDefaultScoper/__tests__/checkSimpleModels.test.ts
+++ b/packages/test/src/testDefaultScoper/__tests__/checkSimpleModels.test.ts
@@ -1,6 +1,7 @@
 import { DSmodel } from "../language/gen";
 import { SimpleModelCreator } from "./SimpleModelCreator";
 import { DSmodelEnvironment } from "../config/gen/DSmodelEnvironment";
+import { describe, test, expect } from "vitest"
 
 function print(prefix: string, visibleNames: string[]) {
     let printable: string = "";

--- a/packages/test/src/testDefinedScoper/__tests__/check1.test.ts
+++ b/packages/test/src/testDefinedScoper/__tests__/check1.test.ts
@@ -1,6 +1,7 @@
 import { DSmodel } from "../language/gen";
 import { SimpleModelCreator } from "./ModelCreator";
 import { DSmodelEnvironment } from "../config/gen/DSmodelEnvironment";
+import { describe, test, expect } from "vitest"
 
 function print(prefix: string, visibleNames: string[]) {
     let printable: string = "";

--- a/packages/test/src/testLangConstructs/__tests__/checkPrimProps.test.ts
+++ b/packages/test/src/testLangConstructs/__tests__/checkPrimProps.test.ts
@@ -1,4 +1,5 @@
 import { ConceptWithPrimProps, ConceptWithAllProps, ConceptWithBasePrim, ConceptWithInheritanceTree1 } from "../language/gen";
+import { describe, test, expect } from "vitest"
 
 describe("Checking primitive properties", () => {
     let concept1 = ConceptWithPrimProps.create({

--- a/packages/test/src/testLangConstructs/__tests__/checkStdLib.test.ts
+++ b/packages/test/src/testLangConstructs/__tests__/checkStdLib.test.ts
@@ -2,6 +2,7 @@ import { FreLanguage } from "@freon4dsl/core";
 import { AllEnvironment } from "../config/gen/AllEnvironment";
 import { LimitedConcept1, LimitedWithBase, LimitedWithInheritanceTree, LimitedWithInterface } from "../language/gen";
 import { AllStdlib } from "../stdlib/gen/AllStdlib";
+import { describe, it, test, expect } from "vitest"
 
 describe("Checking stdlib for Lang Constructs", () => {
     AllEnvironment.getInstance();

--- a/packages/test/src/testNoParserAvailable/__tests__/TryParser.test.ts
+++ b/packages/test/src/testNoParserAvailable/__tests__/TryParser.test.ts
@@ -1,6 +1,7 @@
 import { FileHandler } from "../../utils/FileHandler";
 import { DemoEnvironment } from "../config/gen/DemoEnvironment";
 import { Demo, ExModel } from "../language/gen";
+import { describe, test, expect } from "vitest"
 
 describe("Test the STUB that replaces the parser", () => {
     // TODO find a way to create an invalid grammar

--- a/packages/test/src/testPrimPropsGeneration/__tests__/checkPrimProps.test.ts
+++ b/packages/test/src/testPrimPropsGeneration/__tests__/checkPrimProps.test.ts
@@ -1,4 +1,5 @@
 import { BB } from "../language/gen";
+import { describe, test, expect } from "vitest"
 
 describe("Checking generation of primitive properties", () => {
 

--- a/packages/test/src/testproject/__tests__/checkScoper.test.ts
+++ b/packages/test/src/testproject/__tests__/checkScoper.test.ts
@@ -3,6 +3,7 @@ import { TestStartEnvironment } from "../config/gen/TestStartEnvironment";
 import { AA, BB, CC, KK, TestLimited, XX, ZZ } from "../language/gen";
 import { TestStartScoper } from "../scoper/gen";
 import { TestStartStdlib } from "../stdlib/gen/TestStartStdlib";
+import { describe, test, expect, beforeEach } from "vitest"
 
 describe("Checking stdlib for Demo", () => {
     TestStartEnvironment.getInstance();

--- a/packages/test/src/testproject/__tests__/checkStdLib.test.ts
+++ b/packages/test/src/testproject/__tests__/checkStdLib.test.ts
@@ -2,6 +2,7 @@ import { FreLanguage, jsonAsString } from "@freon4dsl/core";
 import { KK, TestLimited, XX, ZZ } from "../language/gen";
 import { TestStartEnvironment } from "../config/gen/TestStartEnvironment";
 import { TestStartStdlib } from "../stdlib/gen/TestStartStdlib";
+import { describe, test, expect } from "vitest"
 
 describe("Checking stdlib for Demo", () => {
     TestStartEnvironment.getInstance();

--- a/packages/test/src/typer-test8/__tests__/testTyper.test.ts
+++ b/packages/test/src/typer-test8/__tests__/testTyper.test.ts
@@ -2,6 +2,7 @@ import { FreModelSerializer, FreError, FreModelUnit } from "@freon4dsl/core";
 import { XXunit, XX } from "../language/gen";
 import { XXEnvironment } from "../config/gen/XXEnvironment";
 import { FileHandler } from "../../utils/FileHandler";
+import { describe, test, expect, beforeEach } from "vitest"
 
 const writer = XXEnvironment.getInstance().writer;
 const reader = XXEnvironment.getInstance().reader;
@@ -35,9 +36,8 @@ function compareReadAndWrittenFiles(path: string) {
 describe ("Testing Typer on", () => {
     // TODO make an input file in which a number of NamedTypes are created and used
 
-    beforeEach(done => {
+    beforeEach(() => {
         XXEnvironment.getInstance();
-        done();
     });
 
     test ("literal expressions", () => {

--- a/packages/test/src/utils/HelperFunctions.ts
+++ b/packages/test/src/utils/HelperFunctions.ts
@@ -1,5 +1,6 @@
 import { FreModelSerializer, FreModel, FreModelUnit, FreReader, FreWriter } from "@freon4dsl/core";
 import { FileHandler } from "./FileHandler";
+import { expect} from "vitest"
 
 const serial: FreModelSerializer = new FreModelSerializer();
 const handler = new FileHandler();

--- a/packages/test/src/vehicles/__tests__/TestVehicles.test.ts
+++ b/packages/test/src/vehicles/__tests__/TestVehicles.test.ts
@@ -1,6 +1,7 @@
 import { VehicleModelEnvironment } from "../config/gen/VehicleModelEnvironment";
 import { VehicleModel, VehicleUnit } from "../language/gen";
 import { compareReadAndWrittenUnits } from "../../utils/HelperFunctions";
+import { describe, test } from "vitest"
 
 const writer = VehicleModelEnvironment.getInstance().writer;
 const reader = VehicleModelEnvironment.getInstance().reader;


### PR DESCRIPTION
Replace jest by vitest, because vitest supports TypeScript and ES Modules.