### PR TITLE
Add testcases for initializing properties in .ast language.

### DIFF
--- a/packages/meta/src/__tests__/language-tests/checkCheckingErrors.test.ts
+++ b/packages/meta/src/__tests__/language-tests/checkCheckingErrors.test.ts
@@ -195,10 +195,19 @@ describe("Checking language parser on checking errors", () => {
         try {
             parser.parse(testdir + "test11.ast");
         } catch (e: unknown) {
-            if (e instanceof Error) {            // console.log(checker.errors.map(err => err));
-                expect(e.message).toBe(`checking errors (1).`);
-                console.log("ERRORS: " + checker.errors)
+            if (e instanceof Error) {
+                // console.log("ERRORS: " + checker.errors.map(e => e + "\n"))
+                expect(e.message).toBe(`checking errors (9).`);
                 expect(checker.errors.includes("Non-primitive property 'prop1' may not have an initial value [file: test11.ast:14:12].")).toBeTruthy();
+                expect(checker.errors.includes("Type of 'this should be a number' (string) does not fit type (number) of property 'numberProp1' [file: test11.ast:15:5].")).toBeTruthy();
+                expect(checker.errors.includes("Type of 'true' (boolean) does not fit type (number) of property 'numberProp2' [file: test11.ast:16:5].")).toBeTruthy();
+                expect(checker.errors.includes("Type of 'Color:red' (Color) does not fit type (number) of property 'numberProp3' [file: test11.ast:17:5].")).toBeTruthy();
+                expect(checker.errors.includes("Non-primitive property 'prop1' may not have an initial value [file: test11.ast:14:12].")).toBeTruthy();
+                expect(checker.errors.includes("Property limitedProp2 has incorrect initializer type, should be a limited literal [file: test11.ast:20:5].")).toBeTruthy();
+                expect(checker.errors.includes("Property limitedProp3 has incorrect initializer type, should be a limited literal [file: test11.ast:21:5].")).toBeTruthy();
+                expect(checker.errors.includes("Type of Size does not fit Color of limitedProp4 [file: test11.ast:22:5].")).toBeTruthy();
+                expect(checker.errors.includes("Type of Size does not fit Color of limitedProp5 [file: test11.ast:23:5].")).toBeTruthy();
+                expect(checker.errors.includes("Literal 'green' does not exist in limited 'Color' at [file: test11.ast:24:19].")).toBeTruthy()
             }
         }
     });

--- a/packages/meta/src/__tests__/language-tests/faultyDefFiles/checking-errors/test11.ast
+++ b/packages/meta/src/__tests__/language-tests/faultyDefFiles/checking-errors/test11.ast
@@ -12,8 +12,26 @@ modelunit testUnit {
 concept YY  {
     // ERROR: no initial value allowed in concept properties
     prop1: ZZ = 10;
+    numberProp1: number = "this should be a number";
+    numberProp2: number = true;
+    numberProp3: number = Color:red;
+    
+    limitedProp1: Color = Color:red;
+    limitedProp2: Color = 1;
+    limitedProp3: Color = "red";
+    limitedProp4: Color = Size:small;
+    limitedProp5: Color = Size:huge;
+    limitedProp6: Color = Color:green;
 }
 
 concept ZZ {
     name: identifier;
+}
+
+limited Color {
+    red; yellow; blue;
+}
+
+limited Size {
+    larger; medium; small;
 }

--- a/packages/meta/src/languagedef/checking/CommonChecker.ts
+++ b/packages/meta/src/languagedef/checking/CommonChecker.ts
@@ -1,12 +1,15 @@
 import {
     FreMetaClassifier,
     FreMetaConcept,
-    MetaElementReference, FreMetaPrimitiveProperty,
+    MetaElementReference,
+    FreMetaPrimitiveProperty,
     FreMetaPrimitiveType,
     FreMetaPrimitiveValue,
-    FreMetaProperty
+    FreMetaProperty,
+    FreMetaLimitedConcept, FreMetaEnumValue
 } from "../metalanguage";
 import { CheckRunner, MetaLogger, Names, ParseLocationUtil } from "../../utils";
+import { CommonSuperTypeUtil } from "./common-super/CommonSuperTypeUtil";
 
 const LOGGER = new MetaLogger("CommonChecker").mute();
 
@@ -19,16 +22,16 @@ export class CommonChecker {
         }
 
         runner.nestedCheck({
-                check: reference.name !== undefined,
-                error: `Classifier reference should have a name ${ParseLocationUtil.location(reference)}.`,
-                whenOk: () => {
-                    runner.nestedCheck(
-                        {
-                            check: reference.referred !== undefined,
-                            error: `Reference to classifier '${reference.name}' cannot be resolved ${ParseLocationUtil.location(reference)}.`
-                        });
-                }
-            });
+            check: reference.name !== undefined,
+            error: `Classifier reference should have a name ${ParseLocationUtil.location(reference)}.`,
+            whenOk: () => {
+                runner.nestedCheck(
+                    {
+                        check: reference.referred !== undefined,
+                        error: `Reference to classifier '${reference.name}' cannot be resolved ${ParseLocationUtil.location(reference)}.`
+                    });
+            }
+        });
     }
 
     public static checkOrCreateNameProperty(classifier: FreMetaClassifier, runner: CheckRunner) {
@@ -85,6 +88,23 @@ export class CommonChecker {
             return true;
         }
         return false;
+    }
+    
+    public static primitiveValueToString(type: FreMetaPrimitiveValue): string {
+        if (type instanceof FreMetaEnumValue) {
+            return type.sourceName
+        } else {
+            return typeof type
+        }
+    }
+
+    /**
+     * returns true if the 'limited' conforms to 'primType'
+     * @param value
+     * @param type
+     */
+    public static checkLimitedType(sub: FreMetaLimitedConcept, superType: FreMetaLimitedConcept): boolean {
+        return CommonSuperTypeUtil.getSupers(sub).includes(superType);
     }
 
     public static makeCopyOfProp(property: FreMetaProperty, classifier: FreMetaConcept): FreMetaProperty {

--- a/packages/meta/src/languagedef/checking/FreLangCheckerPhase1.ts
+++ b/packages/meta/src/languagedef/checking/FreLangCheckerPhase1.ts
@@ -182,18 +182,18 @@ export class FreLangCheckerPhase1 extends CheckerPhase<FreMetaLanguage> {
                 error: `Element '${freProperty.name}' should have a type ${ParseLocationUtil.location(freProperty)}.`,
                 whenOk: () => {
                     CommonChecker.checkClassifierReference(freProperty.typeReference, this.runner);
-                    const realType = freProperty.type;
-                    if (!!realType) { // error message handled by checkClassifierReference
+                    const realPropertyType = freProperty.type;
+                    if (!!realPropertyType) { // error message handled by checkClassifierReference
                         const owningClassifier = freProperty.owningClassifier;
-                        this.checkPropertyType(freProperty, realType);
+                        this.checkPropertyType(freProperty, realPropertyType);
 
-                        const isUnit = (realType instanceof FreMetaUnitDescription);
+                        const isUnit = (realPropertyType instanceof FreMetaUnitDescription);
 
                         // check use of unit types in non-model concepts: may be references only
                         if (isUnit && freProperty.isPart) {
                             this.runner.simpleCheck(
                                 owningClassifier instanceof FreMetaModelDescription,
-                                `Modelunit '${realType.name}' may be used as reference only in a non-model concept ${ParseLocationUtil.location(freProperty.typeReference)}.`);
+                                `Modelunit '${realPropertyType.name}' may be used as reference only in a non-model concept ${ParseLocationUtil.location(freProperty.typeReference)}.`);
                         }
                         // check use of non-unit types in model concept
                         if (owningClassifier instanceof FreMetaModelDescription) {
@@ -201,40 +201,36 @@ export class FreLangCheckerPhase1 extends CheckerPhase<FreMetaLanguage> {
                                 isUnit,
                                 `Type of property '${freProperty.name}' should be a modelunit ${ParseLocationUtil.location(freProperty.typeReference)}.`);
                         }
-                        if (realType instanceof FreMetaLimitedConcept) {
-                            // console.log("FreMetaLimitedConcept for property " + freProperty.name)
-                            // Check whether initialvalue is correct
+                        if (realPropertyType instanceof FreMetaLimitedConcept) {
+                            // Check whether initial value is correct
                             if (freProperty instanceof FreMetaConceptProperty) {
-                                // console.log("    instance of FreMetaConceptProperty with initial " + freProperty.initial );
                                 if (!!freProperty.initial) {
                                     this.runner.nestedCheck({
                                         check: freProperty.initial instanceof FreMetaEnumValue,
-                                        error: `Property ${freProperty.name} has incorrect initializer type, should be a limited literal ${freProperty.location}`,
+                                        error: `Property ${freProperty.name} has incorrect initializer type, should be a limited literal ${ParseLocationUtil.location(freProperty)}.`,
                                         whenOk: () => {
                                             // check reference to enum
                                             const init = freProperty.initial as FreMetaEnumValue
                                             const enumRef = MetaElementReference.create<FreMetaLimitedConcept>(init.sourceName, "FreClassifier")
                                             enumRef.location = freProperty.location
                                             CommonChecker.checkClassifierReference(enumRef, this.runner);
-                                            // console.log(`enumRef referred '${enumRef.referred}`)
                                             if (!!enumRef.referred) {
-                                                // console.log(".     Refferred found")
-                                                // found, now check enum literal name
-                                                const init = freProperty.initial
-                                                if (init instanceof FreMetaEnumValue) {
-                                                    this.runner.simpleCheck((enumRef.referred as FreMetaLimitedConcept).instances.some(i => i.name === init.instanceName),
-                                                        `Literal '${init.instanceName}' does not exist in limited '${init.sourceName}' at ${ParseLocationUtil.location(freProperty.typeReference)}`)
-                                                } else {
-                                                    this.runner.simpleCheck(false,
-                                                        `Non-primitive property '${freProperty.name} may not have an initial value ${ParseLocationUtil.location(freProperty.typeReference)}`)
-                                                }
+                                                this.runner.nestedCheck({
+                                                    check: CommonChecker.checkLimitedType(enumRef.referred, realPropertyType),
+                                                    error: `Type of ${enumRef.referred.name} does not fit ${realPropertyType.toString()} of ${freProperty.name} ${ParseLocationUtil.location(freProperty)}.`,
+                                                    whenOk: () => {
+                                                        // found, now check limited instance name
+                                                        this.runner.simpleCheck((enumRef.referred as FreMetaLimitedConcept).instances.some(i => i.name === init.instanceName),
+                                                            `Literal '${init.instanceName}' does not exist in limited '${init.sourceName}' at ${ParseLocationUtil.location(freProperty.typeReference)}.`)
+                                                    }
+                                                })
                                             }
                                         }
                                     })
                                 } 
                             }
                         } else {
-                            // It is a concept, not a limited
+                            // The type of the property is a concept, not a limited
                             if (freProperty instanceof FreMetaConceptProperty) {
                                     this.runner.simpleCheck(freProperty.initial === undefined,
                                         `Non-primitive property '${freProperty.name}' may not have an initial value ${ParseLocationUtil.location(freProperty.typeReference)}.`)
@@ -310,7 +306,7 @@ export class FreLangCheckerPhase1 extends CheckerPhase<FreMetaLanguage> {
                             `Initial value of property '${element.name}' should be a single value ${ParseLocationUtil.location(element)}.`);
                         if (element.initialValue !== null && element.initialValue !== undefined) { // the property has an initial value, so check it
                             this.runner.simpleCheck(CommonChecker.checkValueToType(element.initialValue, myType as FreMetaPrimitiveType),
-                                `Type of '${element.initialValue}' (${typeof element.initialValue}) does not fit type (${element.type.name}) of property '${element.name}' ${ParseLocationUtil.location(element)}.`);
+                                `Type of '${element.initialValue.toString()}' (${CommonChecker.primitiveValueToString(element.initialValue)}) does not fit type (${element.type.name}) of property '${element.name}' ${ParseLocationUtil.location(element)}.`);
                         }
                     } else {
                         // this.runner.simpleCheck(element.initialValue === null || element.initialValue === undefined,
@@ -318,7 +314,7 @@ export class FreLangCheckerPhase1 extends CheckerPhase<FreMetaLanguage> {
                         if (element.initialValueList.length > 0) { // the property has an initial value, so check it
                             element.initialValueList.forEach(value => {
                                 this.runner.simpleCheck(CommonChecker.checkValueToType(value, myType as FreMetaPrimitiveType),
-                                    `Type of '${value}' (${typeof element.initialValue}) does not fit type (${element.type.name}[]) of property '${element.name}' ${ParseLocationUtil.location(element)}.`);
+                                    `Type of '${value}' (${CommonChecker.primitiveValueToString(element.initialValue)}) does not fit type (${element.type.name}[]) of property '${element.name}' ${ParseLocationUtil.location(element)}.`);
                             });
                         }
                     }

--- a/packages/meta/src/languagedef/checking/FreLangCheckerPhase2.ts
+++ b/packages/meta/src/languagedef/checking/FreLangCheckerPhase2.ts
@@ -196,12 +196,12 @@ export class FreLangCheckerPhase2 extends CheckerPhase<FreMetaLanguage> {
                                         const myPropType: FreMetaPrimitiveType = myProp.type as FreMetaPrimitiveType;
                                         if (!myProp.isList) {
                                             this.runner.simpleCheck(CommonChecker.checkValueToType(freInstanceProperty.value, myPropType),
-                                                `Type of '${freInstanceProperty.value}' (${typeof freInstanceProperty.value}) does not fit type (${myPropType.name}) of property '${freInstanceProperty.name}' ${ParseLocationUtil.location(freInstanceProperty)}.`);
+                                                `Type of '${freInstanceProperty.value}' (${CommonChecker.primitiveValueToString(freInstanceProperty.value)}) does not fit type (${myPropType.name}) of property '${freInstanceProperty.name}' ${ParseLocationUtil.location(freInstanceProperty)}.`);
                                         } else {
                                             if (!!freInstanceProperty.valueList) {
                                                 freInstanceProperty.valueList.forEach(value => {
                                                     this.runner.simpleCheck(CommonChecker.checkValueToType(value, myPropType),
-                                                        `Type of '${value}' (${typeof value}) does not fit type (${myPropType.name}) of property '${freInstanceProperty.name}' ${ParseLocationUtil.location(freInstanceProperty)}.`);
+                                                        `Type of '${CommonChecker.primitiveValueToString(value)}' (${typeof value}) does not fit type (${myPropType.name}) of property '${freInstanceProperty.name}' ${ParseLocationUtil.location(freInstanceProperty)}.`);
                                                 });
                                             }
                                         }

--- a/packages/meta/src/languagedef/checking/common-super/CommonSuperTypeUtil.ts
+++ b/packages/meta/src/languagedef/checking/common-super/CommonSuperTypeUtil.ts
@@ -36,7 +36,7 @@ export class CommonSuperTypeUtil {
      * @param inCls
      * @private
      */
-    private static getSupers(inCls: FreMetaClassifier): OrderedList<FreMetaClassifier> {
+    public static getSupers(inCls: FreMetaClassifier): OrderedList<FreMetaClassifier> {
         const classes: OrderedList<FreMetaClassifier> = new OrderedList<FreMetaClassifier>();
         if (!!inCls) {
             let nextLevel: OrderedList<FreMetaClassifier> = new OrderedList<FreMetaClassifier>();

--- a/packages/meta/src/languagedef/checking/common-super/OrderedList.ts
+++ b/packages/meta/src/languagedef/checking/common-super/OrderedList.ts
@@ -23,6 +23,10 @@ export class OrderedList<T extends FreMetaLangElement> implements Iterable<T> {
             this.add(t.name, t);
         }
     }
+    
+    includes(elem: T): boolean {
+        return this.getByName(elem.name) !== undefined
+    }
 
     /**
      * Retains only the elements that are contained in the "list".

--- a/packages/meta/src/languagedef/metalanguage/FreMetaLanguage.ts
+++ b/packages/meta/src/languagedef/metalanguage/FreMetaLanguage.ts
@@ -502,6 +502,10 @@ export class FreMetaLimitedConcept extends FreMetaConcept {
         }
         return result;
     }
+    
+    toString(): string {
+        return this.name
+    }
 }
 
 export class FreMetaProperty extends FreMetaLangElement {
@@ -629,6 +633,10 @@ export class FreMetaEnumValue extends FreMetaDefinitionElement {
         this.sourceName = limitedConceptName
         this.instanceName = limitedInstanceName
         this.location = location
+    }
+    
+    toString(): string {
+        return this.sourceName + ":" + this.instanceName;
     }
 }
 // the basic types in the Fre-languages

--- a/packages/meta/src/languagedef/parser/LanguageParser.ts
+++ b/packages/meta/src/languagedef/parser/LanguageParser.ts
@@ -29,7 +29,7 @@ export class LanguageParser extends FreGenericParser<FreMetaLanguage> {
             const idMap = this.parseIds(idJson);
             setIdMap(idMap);
         } else {
-            LOG2USER.info("No id.json found")
+            LOG2USER.log("No id.json found")
         }
         return super.parse(definitionFile);
     }
@@ -41,7 +41,7 @@ export class LanguageParser extends FreGenericParser<FreMetaLanguage> {
             const idMap = this.parseIds(idJson);
             setIdMap(idMap);
         } else {
-            LOG2USER.info("No id.json found")
+            LOG2USER.log("No id.json found")
         }
         return super.parseMulti(filePaths);
     }


### PR DESCRIPTION
After adding initializers for limited properties we need to add test cases for them.
There were missing testcases for primitive property initializers, they have been added as well.