### PR TITLE
replace assert by with to be able to use node v22

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -2,7 +2,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 import dts from 'rollup-plugin-dts';
 
 const production = false;

--- a/packages/samples/DocuProject/rollup.config.js
+++ b/packages/samples/DocuProject/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/Education/rollup.config.js
+++ b/packages/samples/Education/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/Example/rollup.config.js
+++ b/packages/samples/Example/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/MpsExpressions/rollup.config.js
+++ b/packages/samples/MpsExpressions/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/PiLanguage/rollup.config.js
+++ b/packages/samples/PiLanguage/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/RulesLanguage/rollup.config.js
+++ b/packages/samples/RulesLanguage/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/TaxRules/rollup.config.js
+++ b/packages/samples/TaxRules/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/UndoTester/rollup.config.js
+++ b/packages/samples/UndoTester/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {

--- a/packages/samples/UnusedOrInvalid/LionwebM3/rollup.config.js
+++ b/packages/samples/UnusedOrInvalid/LionwebM3/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import pkg from './package.json' assert { type: 'json'};
+import pkg from './package.json' with { type: 'json'};
 
 const config = [
     {


### PR DESCRIPTION
The `assert` keyword is replaced by `with` in node v22,  and `with` also works for v20 and 21.
Therefore changed assert to with to enable node v22.