### PR TITLE
Parser now uses default if parser p[rojection is missing, test change…

### DIFF
--- a/packages/meta/src/parsergen/parserTemplates/WriterTemplate.ts
+++ b/packages/meta/src/parsergen/parserTemplates/WriterTemplate.ts
@@ -486,8 +486,9 @@ export class WriterTemplate {
                           * Unparsing of '${name}' according to projection '${projection.name}'.
                           */`;
         // take care of named projections, the unparse method gets a different name
+        // except when it is the parser projection, this replaces the default projection with the same name.
         let methodName: string = `unparse${name}`;
-        if (projection.name !== this.currentProjectionGroup?.name) {
+        if (projection.name !== this.currentProjectionGroup?.name && projection.name !== "parser") {
             methodName += "_" + projection.name;
         }
         if (!!lines) {
@@ -611,7 +612,8 @@ export class WriterTemplate {
                 if (!!foundProjection) {
                     ListUtil.addIfNotPresent<FreEditClassifierProjection>(this.namedProjections, foundProjection);
                 }
-                result += `this.unparse${Names.classifier(item.superRef.referred)}_${item.projectionName}(modelelement, short);`;
+                result += `// SUPER
+                this.unparse${Names.classifier(item.superRef.referred)}_${item.projectionName}(modelelement, short);`;
             } else {
                 // use the normal unparse method
                 result += `this.unparse${Names.classifier(item.superRef.referred)}(modelelement, short);`;

--- a/packages/test/src/vehicles/defs/Vehicles-default.edit
+++ b/packages/test/src/vehicles/defs/Vehicles-default.edit
@@ -3,3 +3,19 @@ editor default
 global {
     boolean [GOOD | WRONG] // are the strings used to display a boolean value
 }
+
+Steamboat  {
+[
+    ${typeName} Manufacturer: ${manufacturer:additional}
+    [=> IsMotorised]
+    NrOfPassengers: ${nrOfPassengers}
+    PreferedWaterWay: ${preferedWaterWay}
+    Is a heritage ship: ${isHeritage}
+]}
+
+PetrolCar {
+[
+    ${typeName} [=> Vehicle:additional]
+    [=> IsMotorised]
+    max content of boot (in m2): ${bootContent}
+]}

--- a/packages/test/src/vehicles/defs/Vehicles-parser.edit
+++ b/packages/test/src/vehicles/defs/Vehicles-parser.edit
@@ -45,21 +45,7 @@ Bike {
     Size of tyres: ${tyreSize}
 ]}
 
-Steamboat  {
-[
-    ${typeName} Manufacturer: ${manufacturer:additional}
-    [=> IsMotorised]
-    NrOfPassengers: ${nrOfPassengers}
-    PreferedWaterWay: ${preferedWaterWay}
-    Is a heritage ship: ${isHeritage}
-]}
-
-PetrolCar {
-[
-    ${typeName} [=> Vehicle:additional]
-    [=> IsMotorised]
-    max content of boot (in m2): ${bootContent}
-]}
+//Steamboat  and PetrolCar defined in default
 
 SolarCar {
 [


### PR DESCRIPTION
Parser projection needed to have projections for all concepts, which was not the intended behaviour.
Nor the parser projection uses the default if there is none defined in the parser projection itself..