### PR TITLE
Update references when a name is changed

### DIFF
--- a/packages/core/src/ast-utils/AstWalker.ts
+++ b/packages/core/src/ast-utils/AstWalker.ts
@@ -2,6 +2,7 @@ import { FreLanguage, FreLanguageProperty } from "../language/index.js";
 import { FreLogger } from "../logging/index.js";
 import { AstWorker } from "./AstWorker.js";
 import { FreNode } from "../ast/index.js";
+import { isNullOrUndefined } from "../util/index.js"
 
 const LOGGER = new FreLogger("AstWalker");
 
@@ -27,6 +28,7 @@ export class AstWalker {
      * @param includeNode tests every child of 'modelelement', if true, it will also be visited
      */
     public walk(node: FreNode, includeNode?: (elem: FreNode) => boolean) {
+        if (isNullOrUndefined(node)) return;
         if (this.myWorkers.length > 0) {
             let stopWalkingThisNode: boolean = false;
             for (const worker of this.myWorkers) {

--- a/packages/core/src/change-manager/FreChangeManager.ts
+++ b/packages/core/src/change-manager/FreChangeManager.ts
@@ -33,10 +33,26 @@ export class FreChangeManager {
     private constructor() {}
 
     // the callbacks to be executed upon the different kind of changes to the model
-    changePrimCallbacks: callback[] = [];
-    changePartCallbacks: callback[] = []; // references are also parts here: the FreNodeReference object is treated as part
-    changeListElemCallbacks: callback[] = [];
-    changeListCallbacks: callback[] = [];
+    private changePrimCallbacks: callback[] = [];
+    private changePartCallbacks: callback[] = []; // references are also parts here: the FreNodeReference object is treated as part
+    private changeListElemCallbacks: callback[] = [];
+    private changeListCallbacks: callback[] = [];
+
+    public subscribeToPrimitive(callback: callback) {
+        FreChangeManager.getInstance().changePrimCallbacks.push(callback);
+    }
+
+    public subscribeToPart(callback: callback) {
+        FreChangeManager.getInstance().changePartCallbacks.push(callback);
+    }
+
+    public subscribeToListElement(callback: callback) {
+        FreChangeManager.getInstance().changeListElemCallbacks.push(callback);
+    }
+
+    public subscribeToList(callback: callback) {
+        FreChangeManager.getInstance().changeListCallbacks.push(callback);
+    }
 
     /**
      * Reacts to the change of the value of a part property

--- a/packages/core/src/change-manager/FreUndoManager.ts
+++ b/packages/core/src/change-manager/FreUndoManager.ts
@@ -159,10 +159,10 @@ export class FreUndoManager {
      * Constructor subscribes to all changes in the model.
      */
     private constructor() {
-        FreChangeManager.getInstance().changePrimCallbacks.push((delta: FreDelta) => this.addDelta(delta));
-        FreChangeManager.getInstance().changePartCallbacks.push((delta: FreDelta) => this.addDelta(delta));
-        FreChangeManager.getInstance().changeListElemCallbacks.push((delta: FreDelta) => this.addDelta(delta));
-        FreChangeManager.getInstance().changeListCallbacks.push((delta: FreDelta) => this.addDelta(delta));
+        FreChangeManager.getInstance().subscribeToPrimitive((delta: FreDelta) => this.addDelta(delta));
+        FreChangeManager.getInstance().subscribeToPart((delta: FreDelta) => this.addDelta(delta));
+        FreChangeManager.getInstance().subscribeToListElement((delta: FreDelta) => this.addDelta(delta));
+        FreChangeManager.getInstance().subscribeToList((delta: FreDelta) => this.addDelta(delta));
     }
 
     private addDelta(delta: FreDelta) {

--- a/packages/core/src/change-manager/ReferenceUpdateManager.ts
+++ b/packages/core/src/change-manager/ReferenceUpdateManager.ts
@@ -1,0 +1,57 @@
+import { FreLogger } from "../logging/index.js";
+import { FreChangeManager } from "./FreChangeManager.js";
+import { FreModel } from "../ast/index.js"
+import { FreDelta, FrePrimDelta } from "./FreDelta.js"
+import { AstWalker } from "../ast-utils/index.js"
+import { ReferenceUpdateWorker } from "./ReferenceUpdateWorker.js"
+
+const LOGGER = new FreLogger("ReferenceUpdateManager").mute()
+
+/**
+ * Class ReferenceUpdateManager ensures that when a user changes the name of
+ * a node, we update all references that refer to it
+ */
+export class ReferenceUpdateManager {
+    private static theInstance; // the only instance of this class
+
+    /**
+     * This method implements the singleton pattern
+     */
+    public static getInstance(): ReferenceUpdateManager {
+        if (this.theInstance === undefined || this.theInstance === null) {
+            this.theInstance = new ReferenceUpdateManager();
+        }
+        return this.theInstance;
+    }
+
+    /**
+     * The model (AST) for which we keep the references updated.
+     * Should be set up externally.
+     */
+    public freModel: FreModel = null;
+
+    private constructor() {
+        FreChangeManager.getInstance().subscribeToPrimitive((delta: FreDelta) => this.updateReferences(delta));
+    }
+
+    /**
+     * (From the Freon documentation) References are always by name, therefore
+     * the referred concept must have a _name_ property of type identifier.
+     * @param delta
+     * @private
+     */
+    private updateReferences(delta: FreDelta) {
+        if (!!delta.propertyName && delta.propertyName === "name") {
+            const nameDelta: FrePrimDelta = delta as FrePrimDelta;
+            LOGGER.log(` update references for the node ${nameDelta.oldValue}`)
+
+            // set up the walker of the visitor pattern
+            const refWorker = new ReferenceUpdateWorker(nameDelta);
+            const astWalker = new AstWalker();
+            astWalker.myWorkers.push(refWorker);
+            astWalker.walk(this.freModel, () => {
+                return true;
+            });
+        }
+    }
+}

--- a/packages/core/src/change-manager/ReferenceUpdateWorker.ts
+++ b/packages/core/src/change-manager/ReferenceUpdateWorker.ts
@@ -1,0 +1,48 @@
+import { FreNode, FreNodeReference } from "../ast/index.js";
+import { AstWorker } from "../ast-utils/index.js";
+import { FreLanguage, FreLanguageProperty } from "../language/index.js";
+import { FreLogger } from "../logging/index.js";
+import { FrePrimDelta } from "./FreDelta.js"
+
+const LOGGER = new FreLogger("CollectNamesWorker").mute();
+
+/**
+ * AST worker that updates the referenced name per node.
+ * This worker is used in ReferenceUpdateManager when walking the AST.
+ */
+export class ReferenceUpdateWorker implements AstWorker {
+    // The name update, for which we update the references
+    private delta: FrePrimDelta;
+
+    constructor(delta: FrePrimDelta) {
+        this.delta = delta;
+    }
+
+    execBefore(node: FreNode): boolean {
+        // find node properties (children) of type reference
+        const referenceProperties: FreLanguageProperty[] = FreLanguage.getInstance().getPropertiesOfKind(
+            node.freLanguageConcept(),
+            "reference",
+        );
+        // check whether any of references are touched by delta
+        for (const childProp of referenceProperties) {
+            const childValue = FreLanguage.getInstance().getPropertyValue(node, childProp)
+            for(const elem of childValue) {
+                const ref = elem as unknown as FreNodeReference<any>;
+                if (ref.pathname.indexOf(this.delta.oldValue as string) > -1) {
+                    let newPathName = ref.pathname;
+                    newPathName[ref.pathname.indexOf(this.delta.oldValue as string)] = this.delta.newValue as string;
+                    ref.pathname = newPathName;
+                    LOGGER.log(`    updated reference in the node ${node.freId()} to the ${newPathName}`)
+                }
+            }
+        }
+        return false;   //UT: is returning true makes more sense here?
+    }
+
+    // @ts-ignore
+    // parameter is present to adhere to signature of super class
+    execAfter(node: FreNode): boolean {
+        return false;
+    }
+}

--- a/packages/core/src/change-manager/internal.ts
+++ b/packages/core/src/change-manager/internal.ts
@@ -2,3 +2,4 @@ export * from "./FreChangeManager.js";
 export * from "./FreUndoManager.js";
 export * from "./FreDelta.js";
 export * from "./AstChanger.js"
+export * from "./ReferenceUpdateManager.js"

--- a/packages/webapp-lib/src/lib/language/EditorState.ts
+++ b/packages/webapp-lib/src/lib/language/EditorState.ts
@@ -1,14 +1,14 @@
 // This file contains all methods to connect the webapp to the Freon generated language editorEnvironment and to the server that stores the models
 import {
-    BoxFactory,
-    FreError,
-    FreErrorSeverity,
-    FreLogger,
-    FreUndoManager,
-    InMemoryModel,
-    isIdentifier,
-    isNullOrUndefined
-} from "@freon4dsl/core";
+	BoxFactory,
+	FreError,
+	FreErrorSeverity,
+	FreLogger,
+	FreUndoManager,
+	InMemoryModel,
+	isIdentifier,
+	isNullOrUndefined, ReferenceUpdateManager
+} from '@freon4dsl/core';
 import type {
     FreEnvironment,
     FreNode,
@@ -50,6 +50,9 @@ export class EditorState {
         }
         unitNames.ids = store.getUnitIdentifiers();
         units.refs = store.getUnits();
+				if (!isNullOrUndefined(store.model)) {
+					ReferenceUpdateManager.getInstance().freModel = store.model;
+				}
     };
 
     private constructor() {


### PR DESCRIPTION
When the name of the concept is changed, we update all references in the model that use this name: issue #473. 
Note: here we update all references in the model, also those from currently not open units. This might affect the efficiency, in future we might want to update only the references in the currently open unit(s) and postpone (save for later) the update for the references in the units that are not open. 

Plus, in the current set up we save only the current unit. We need to change the whole model to ensure that the newly updated references are saved.

I also did some refactoring: 
- added explicit methods for subscribing to a change in `FreChangeManager`
- added the check for a (not)null node in `AstWalker`