### PR TITLE
Fix: Prevent model unit deletion when rename is called with same oldN…

### DIFF
--- a/packages/core/src/storage/InMemoryModel.ts
+++ b/packages/core/src/storage/InMemoryModel.ts
@@ -211,6 +211,11 @@ export class InMemoryModel {
      * @param unit
      */
     async renameUnit(oldName: string, newName: string, unit: FreModelUnit): Promise<void | InMemoryError> {
+        // If oldName and newName are the same, no rename is needed
+        if (oldName === newName) {
+            LOGGER.log(`renameUnit skipped: oldName and newName are the same (${oldName})`)
+            return
+        }
         LOGGER.log(`renameUnit from ${oldName} to ${newName}`)
         const response = await this.server.renameModelUnit(this.model.name, oldName, newName, unit)
         if (response.errors.length > 0) {

--- a/packages/core/src/storage/server/LionWebRepositoryCommunication.ts
+++ b/packages/core/src/storage/server/LionWebRepositoryCommunication.ts
@@ -221,11 +221,16 @@ export class LionWebRepositoryCommunication implements IServerCommunication {
 
     async renameModelUnit(modelName: string, oldName: string, newName: string, unit: FreNamedNode): Promise<VoidServerResponse> {
         LOGGER.log(`renameModelUnit ${modelName}/${oldName} to ${modelName}/${newName}`);
+        // If oldName and newName are the same, no rename is needed
+        if (oldName === newName) {
+            LOGGER.log(`renameModelUnit skipped: oldName and newName are the same (${oldName})`);
+            return { errors: [] };
+        }
         this.client.repository = modelName;
         // put the unit and its interface under the new name
         await this.saveModelUnit(modelName, { name: newName, id: unit.freId(), type: unit.freLanguageConcept() }, unit);
         // remove the old unit and interface
-        await this.deleteModelUnit(modelName, { name: unit.name, id: unit.freId(), type: unit.freLanguageConcept() });
+        await this.deleteModelUnit(modelName, { name: oldName, id: unit.freId(), type: unit.freLanguageConcept() });
         return { errors: [] }
     }
 }

--- a/packages/core/src/storage/server/ServerCommunication.ts
+++ b/packages/core/src/storage/server/ServerCommunication.ts
@@ -314,6 +314,11 @@ export class ServerCommunication implements IServerCommunication {
 
     async renameModelUnit(modelName: string, oldName: string, newName: string, unit: FreNamedNode): Promise<VoidServerResponse> {
         LOGGER.log(`ServerCommunication.renameModelUnit ${modelName}/${oldName} to ${modelName}/${newName}`);
+        // If oldName and newName are the same, no rename is needed
+        if (oldName === newName) {
+            LOGGER.log(`ServerCommunication.renameModelUnit skipped: oldName and newName are the same (${oldName})`);
+            return { errors: [] };
+        }
         // put the unit under the new name
         await this.saveModelUnit(modelName, { name: newName, id: unit.freId(), type: unit.freLanguageConcept() }, unit);
         // remove the old unit


### PR DESCRIPTION
…ame and newName

- Add guard clause in InMemoryModel.renameUnit() to skip operation when oldName === newName
- Add guard clause in ServerCommunication.renameModelUnit() to skip operation when oldName === newName
- Add guard clause in LionWebRepositoryCommunication.renameModelUnit() to skip operation when oldName === newName
- Fix bug in LionWebRepositoryCommunication.renameModelUnit() to use oldName instead of unit.name when deleting old unit

This prevents the bug where a unit file is deleted when renameModelUnit is called with identical oldName and newName values, which can occur when a unit's name property is redundantly set to the same value.