### PR TITLE
(de)serialize Freon Limited <==> LionWeb Enumeration

### DIFF
--- a/packages/core/src/editor/simplifiedBoxAPI/box-util-helpers/UtilRefHelpers.ts
+++ b/packages/core/src/editor/simplifiedBoxAPI/box-util-helpers/UtilRefHelpers.ts
@@ -14,10 +14,10 @@ import { qualifiedName } from '../../../ast/index.js';
 import { RoleProvider } from "../RoleProvider.js";
 import type { FreScoper } from "../../../scoper/index.js";
 import { BehaviorExecutionResult } from "../../util/index.js";
-import { BoxUtil, FreListInfo } from "../BoxUtil.js";
+import { BoxUtil, type FreListInfo } from "../BoxUtil.js";
 import { UtilCommon } from "./UtilCommon.js";
 import { FreLanguage } from "../../../language/index.js";
-import { FreEditor } from "../../FreEditor.js";
+import { type FreEditor } from "../../FreEditor.js";
 import { FreUtils, isNullOrUndefined, notNullOrUndefined } from '../../../util/index.js';
 
 const LOGGER = new FreLogger("UtilRefHelpers")

--- a/packages/core/src/scoper/FreCompositeScoper.ts
+++ b/packages/core/src/scoper/FreCompositeScoper.ts
@@ -2,8 +2,8 @@ import type { FreNamedNode, FreNode, FreNodeReference } from '../ast/index.js';
 import { FreLogger } from "../logging/index.js";
 import { type FreScoper } from "./FreScoper.js";
 import { notNullOrUndefined } from '../util/index.js';
-import { FreNamespaceInfo } from './FreNamespaceInfo.js';
-import { FreNamespace } from './FreNamespace.js';
+import { type FreNamespaceInfo } from './FreNamespaceInfo.js';
+import { type FreNamespace } from './FreNamespace.js';
 import { findEnclosingNamespace, resolvePathStartingInNamespace } from './ScoperUtil.js';
 
 const LOGGER = new FreLogger("FreCompositeScoper").mute();
@@ -27,7 +27,7 @@ export class FreCompositeScoper implements FreScoper {
      * @param refToResolve
      */
     resolvePathName(refToResolve: FreNodeReference<FreNamedNode>): FreNamedNode | undefined {
-        // console.log('resolving: ', toBeResolved.pathname)
+        // console.log('resolving: ', refToResolve.pathname)
         let baseNamespace: FreNamespace = findEnclosingNamespace(refToResolve);
         let currentNamespace: FreNamespace = baseNamespace;
         let found: FreNamedNode = undefined;

--- a/packages/core/src/storage/serializer/FreLionwebSerializer.ts
+++ b/packages/core/src/storage/serializer/FreLionwebSerializer.ts
@@ -178,14 +178,24 @@ export class FreLionwebSerializer implements FreSerializer {
         }
         // Store id, so it will not be used for new instances
         FreUtils.nodeIdProvider.usedId(tsObject.freId());
-        this.convertPrimitiveProperties(tsObject, conceptMetaPointer.key, node);
+        const parsedLimiteds = this.convertPrimitiveProperties(tsObject, conceptMetaPointer.key, node);
         const parsedChildren = this.convertChildProperties(conceptMetaPointer.key, node);
         const parsedReferences = this.convertReferenceProperties(conceptMetaPointer.key, node);
         // LOGGER.info(`toTypeScriptInstanceInternal result ${jsonAsString({ freNode: tsObject, children: parsedChildren, references: parsedReferences })}`)
-        return { freNode: tsObject, children: parsedChildren, references: parsedReferences };
+        return { freNode: tsObject, children: parsedChildren, references: parsedReferences.concat(parsedLimiteds) };
     }
 
-    private convertPrimitiveProperties(freNode: FreNode, concept: string, jsonObject: LionWebJsonNode): void {
+    /**
+     * Convert primitive property values and add value directly into the `freNode`.
+     * Any limited values found will be returned in tje list of `ParsedReference`s
+     * @param freNode       Node being converted into.
+     * @param concept       The Conceot of the `freNode`.
+     * @param jsonObject    The object being converted from.
+     * @return              The parsed references for limited properties.
+     * @private
+     */
+    private convertPrimitiveProperties(freNode: FreNode, concept: string, jsonObject: LionWebJsonNode): ParsedReference[] {
+        const parsedLimiteds: ParsedReference[] = []
         const jsonProperties = jsonObject.properties;
         FreUtils.CHECK(
             Array.isArray(jsonProperties),
@@ -200,7 +210,7 @@ export class FreLionwebSerializer implements FreSerializer {
                 propertyMetaPointer.key,
             );
             if (property === undefined || property === null) {
-                LOGGER.error("NULL PROPERTY for key " + propertyMetaPointer.key);
+                LOGGER.error(`NULL PROPERTY for key ${propertyMetaPointer.key} in concept ${concept}`);
             }
             if (isNullOrUndefined(property)) {
                 // FIXME known prpblems
@@ -210,10 +220,29 @@ export class FreLionwebSerializer implements FreSerializer {
                 continue;
             }
             FreUtils.CHECK(!property.isList, "Lionweb does not support list properties: " + property.name);
-            FreUtils.CHECK(
-                property.propertyKind === "primitive",
-                "Primitive value found for non primitive property: " + property.name,
-            );
+            if (property.propertyKind !== "primitive") {
+                console.error("Primitive value found for non primitive property: " + property.name)
+                // continue
+            }
+            // FreUtils.CHECK(
+            //     property.propertyKind === "primitive",
+            //     "Primitive value found for non primitive property: " + property.name,
+            // );
+            // console.log(`DESER prop '${property.name}': '${property.type}' value '${jsonProperty.value}'`)
+            const propertyConcept = FreLanguage.getInstance().concept(property.type)
+            // LIONWEB: Handle Limited references as primitive properties, because limited maps to Enumeration in LionWeb.
+            if (notNullOrUndefined(propertyConcept) && propertyConcept.isLimited) {
+                console.log(`DE-SERIALIZING LIMITED PROPERTY ${propertyConcept} for property ${property.name}`)
+                parsedLimiteds.push({
+                    featureName: property.name,
+                    isList: property.isList,
+                    typeName: property.type,
+                    referredId: null,
+                    resolveInfo: jsonProperty.value,
+                });
+                continue
+            }
+
             const value = jsonProperty.value;
             if (isNullOrUndefined(value)) {
                 if (property.isOptional) {
@@ -244,6 +273,7 @@ export class FreLionwebSerializer implements FreSerializer {
                 freNode[property.name] = value === "true";
             }
         }
+        return parsedLimiteds
     }
 
     private convertMetaPointer(jsonObject: LionWebJsonMetaPointer, parent: Object): LionWebJsonMetaPointer {
@@ -341,6 +371,12 @@ export class FreLionwebSerializer implements FreSerializer {
             for (const item of jsonValue) {
                 if (notNullOrUndefined(item)) {
                     if (typeof item === "object") {
+                        const propertyConcept = FreLanguage.getInstance().concept(property.type)
+                        // LIONWEB: Handle Limited references as primitive properties, because limited maps to Enumeration in LionWeb.
+                        if (notNullOrUndefined(propertyConcept) && propertyConcept.isLimited) {
+                            console.log(`WARNING DE-SERIALIZING LIMITED AS REFERENCE ${propertyConcept} for property ${property.name}`)
+                            
+                        }
                         // New reference format with resolveInfo
                         parsedReferences.push({
                             featureName: property.name,
@@ -484,6 +520,32 @@ export class FreLionwebSerializer implements FreSerializer {
                 result.containments.push(child);
                 break;
             case "reference":
+                const propertyConcept = FreLanguage.getInstance().concept(p.type) 
+                // LIONWEB: Handle Limited references as primitive properties, because limited maps to Enumeration in LionWeb.
+                if (notNullOrUndefined(propertyConcept) && propertyConcept.isLimited) {
+                    console.log(`SERIALIZING LIMITED ${propertyConcept} for property ${p.name}`)
+                    const limitedRefValue = parentNode[p.name];
+                    if (p.isList) {
+                        LOGGER.error(`Limited list is not supported by LionWeb, stored JSON will be incompatible with LionWeb.`)
+                        // const limitedValue = (limitedRefValue as FreNodeReference<any>[])?.map(l => l.name)
+                        // console.log(`   LIST limitedref   is ${(limitedRefValue as FreNodeReference<any>)?.name}`)
+                        // console.log(`   limitedValue is ${limitedValue}`)
+                        // console.log(`   metapointer ${p.key}, ${p.language}`)
+                        // result.properties.push({
+                        //     property: this.createMetaPointer(p.key, p.language),
+                        //     value: propertyValueToString(limitedValue),
+                        // })
+                    } else {
+                        const name = (limitedRefValue as FreNodeReference<any>)?.name
+                        console.log(`   limitedref for property ${p.name}  is ${name}`)
+                        console.log(`   metapointer ${p.key}, ${p.language}`)
+                        result.properties.push({
+                            property: this.createMetaPointer(p.key, p.language),
+                            value: propertyValueToString(name),
+                        })
+                        return
+                    }
+                }
                 const lwReference: LionWebJsonReference = {
                     reference: this.createMetaPointer(p.key, p.language),
                     targets: [],

--- a/packages/core/src/storage/serializer/FreLionwebSerializer.ts
+++ b/packages/core/src/storage/serializer/FreLionwebSerializer.ts
@@ -187,9 +187,9 @@ export class FreLionwebSerializer implements FreSerializer {
 
     /**
      * Convert primitive property values and add value directly into the `freNode`.
-     * Any limited values found will be returned in tje list of `ParsedReference`s
+     * Any limited values found will be returned in the list of `ParsedReference`s
      * @param freNode       Node being converted into.
-     * @param concept       The Conceot of the `freNode`.
+     * @param concept       The Concept of the `freNode`.
      * @param jsonObject    The object being converted from.
      * @return              The parsed references for limited properties.
      * @private
@@ -224,10 +224,6 @@ export class FreLionwebSerializer implements FreSerializer {
                 console.error("Primitive value found for non primitive property: " + property.name)
                 // continue
             }
-            // FreUtils.CHECK(
-            //     property.propertyKind === "primitive",
-            //     "Primitive value found for non primitive property: " + property.name,
-            // );
             // console.log(`DESER prop '${property.name}': '${property.type}' value '${jsonProperty.value}'`)
             const propertyConcept = FreLanguage.getInstance().concept(property.type)
             // LIONWEB: Handle Limited references as primitive properties, because limited maps to Enumeration in LionWeb.

--- a/packages/meta/src/lionwebgen/LionWebGenerator.ts
+++ b/packages/meta/src/lionwebgen/LionWebGenerator.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { FreMetaLanguage } from "../languagedef/metalanguage/index.js";
+import { type FreMetaLanguage } from "../languagedef/metalanguage/index.js";
 import { LionWebTemplate } from "./templates/LionWebTemplate.js";
 import { MetaLogger } from '../utils/no-dependencies/index.js';
 import { FileUtil, GenerationStatus } from '../utils/file-utils/index.js';

--- a/packages/meta/src/lionwebgen/templates/LionWebTemplate.ts
+++ b/packages/meta/src/lionwebgen/templates/LionWebTemplate.ts
@@ -324,7 +324,7 @@ export class LionWebTemplate {
                     reference: MetaPointers.PropertyType,
                     targets: [
                         {
-                            resolveInfo: prop.type.name,
+                            resolveInfo: this.toLionWebPropertyType(prop),
                             // @ts-ignore
                             reference: (prop.type.id === "" ? null : prop.type.id)
                         }
@@ -541,6 +541,29 @@ export class LionWebTemplate {
             parent: parent.id
         };
         return result;
+    }
+
+    /**
+     * Primitive property type conversion
+     * @param prop
+     */
+    toLionWebPropertyType(prop: FreMetaProperty): string {
+        switch (prop.type.name) {
+            case "number":
+                return "Integer"
+                break
+            case "string":
+                return "String"
+                break
+            case "boolean":
+                return "Boolean"
+                break
+            case "identifier":
+                return "String"
+                break
+            default:
+                return prop.type.name
+        }
     }
 }
 


### PR DESCRIPTION
Freon Limited (being a concept) should map to LionWeb Enumeration (being a primitive) and vice versa.

Did some import cleanup as well.