### PR TITLE
fix: guard against missing constructor in getKnownTableProjectionsFor

### DIFF
--- a/packages/core/src/editor/projections/FreProjectionHandler.ts
+++ b/packages/core/src/editor/projections/FreProjectionHandler.ts
@@ -251,7 +251,11 @@ export class FreProjectionHandler {
 
     getKnownTableProjectionsFor(conceptName: string): string[] {
         LOGGER.log("getKnownTableProjectionsFor: " + conceptName);
-        const providerConstructor = this.conceptNameToProviderConstructor.get(conceptName)(this);
+        const constructorFunction = this.conceptNameToProviderConstructor.get(conceptName);
+        if (!constructorFunction) {
+            return [];
+        }
+        const providerConstructor = constructorFunction(this);
         if (!!providerConstructor) {
             return providerConstructor.knownTableProjections;
         } else {


### PR DESCRIPTION
## Summary
- Add null check before calling the constructor function from Map.get()
- Previously crashed if the concept name was not in the map

## Changes
- `FreProjectionHandler.ts`: Check if constructorFunction exists before calling it