### PR TITLE
fix: use Array.isArray check in FreLogger.log

### DIFF
--- a/packages/core/src/logging/FreLogger.ts
+++ b/packages/core/src/logging/FreLogger.ts
@@ -73,7 +73,7 @@ export class FreLogger {
         if (!FreLogger.muteAll && this.active) {
             this.logToConsole(FreLogger.FG_BLACK, this.category + ": " + this.message(msg));
         } else if (tagOrTags !== undefined && tagOrTags !== null) {
-            const tags: string[] = typeof tagOrTags === "string" ? [tagOrTags] : (tagOrTags as string[]);
+            const tags: string[] = typeof tagOrTags === "string" ? [tagOrTags] : (Array.isArray(tagOrTags) ? tagOrTags : []);
             for (const tag of tags) {
                 if (!FreLogger.mutedLogs.includes(tag)) {
                     this.logToConsole(FreLogger.FG_BLACK, this.category + "." + tag + ": " + this.message(msg));


### PR DESCRIPTION
## Summary
- The tagOrTags parameter was cast directly to string[] without checking if it was actually an array
- If a non-string, non-array value was passed, this would crash when iterating

## Changes
- `FreLogger.ts`: Use Array.isArray() for safe type checking