### PR TITLE
fix: throw error instead of console.log on type mismatch

### DIFF
--- a/packages/core/src/editor/boxes/externalBoxes/StringReplacerBox.ts
+++ b/packages/core/src/editor/boxes/externalBoxes/StringReplacerBox.ts
@@ -35,11 +35,12 @@ export class StringReplacerBox extends AbstractExternalPropertyBox {
                 this.node[this.propertyName] = newValue;
             });
         } else {
-            console.log(
-                "StringReplacerBox.setPropertyValue type error: trying to set property of type " +
+            throw new Error(
+                "StringReplacerBox.setPropertyValue: type mismatch — property type is '" +
                     this.getPropertyType() +
-                    " to a value of type " +
-                    typeof newValue,
+                    "' but value type is '" +
+                    typeof newValue +
+                    "'. Check that the box is bound to a string property (e.g. correct node and propertyName).",
             );
         }
     }


### PR DESCRIPTION
## Summary
- When setPropertyValue receives a value whose type doesn't match the property type, the old code silently logged a message
- This made debugging difficult as the issue would go unnoticed
- Now throws an error with a clear diagnostic message

## Changes
- `StringReplacerBox.ts`: Replace console.log with throw new Error