### PR TITLE
fix: add firstLeaf/lastLeaf for keyboard navigation

### DIFF
--- a/packages/core/src/editor/boxes/externalBoxes/AbstractPropertyWrapperBox.ts
+++ b/packages/core/src/editor/boxes/externalBoxes/AbstractPropertyWrapperBox.ts
@@ -31,4 +31,16 @@ export abstract class AbstractPropertyWrapperBox extends AbstractExternalBox {
     get children(): ReadonlyArray<Box> {
         return [this._childBox] as ReadonlyArray<Box>;
     }
+
+    get firstLeaf(): Box | null {
+        if (!this.isVisible) return null;
+        if (this.selectable) return this;
+        return this._childBox?.firstLeaf ?? null;
+    }
+
+    get lastLeaf(): Box | null {
+        if (!this.isVisible) return null;
+        if (this.selectable) return this;
+        return this._childBox?.lastLeaf ?? null;
+    }
 }


### PR DESCRIPTION
## Summary
- External (wrapped) components could not receive keyboard focus via Tab/Shift-Tab navigation
- They lacked firstLeaf and lastLeaf getter overrides

## Changes
- `AbstractPropertyWrapperBox.ts`: Add firstLeaf and lastLeaf getters