### PR TITLE
fix: pass recursive option to rmSync in deleteDirIfEmpty

### DIFF
--- a/packages/meta/src/utils/file-utils/FileUtil.ts
+++ b/packages/meta/src/utils/file-utils/FileUtil.ts
@@ -135,7 +135,7 @@ export class FileUtil {
         const folder = "./" + dir;
         if (FileUtil.exists(folder)) {
             if (fs.readdirSync(folder).length === 0) {
-                fs.rmSync(folder);
+                fs.rmSync(folder, { recursive: true });
             } else {
                 LOGGER.info("Folder has content: [" + folder + "]");
             }


### PR DESCRIPTION
## Summary
- fs.rmSync() without the recursive option fails on directories
- This adds { recursive: true } to match the behavior in deleteDirAndContent()

## Changes
- `FileUtil.ts`: Add recursive option to rmSync call