### PR TITLE
fix: prevent Svelte 5 state_unsafe_mutation error

### DIFF
--- a/packages/core-svelte/src/lib/components/LayoutComponent.svelte
+++ b/packages/core-svelte/src/lib/components/LayoutComponent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { LAYOUT_LOGGER } from './ComponentLoggers.js';
+    import { untrack, tick } from 'svelte';
 
     /**
      * This component shows a list of various boxes (no 'true' list). It can be shown
@@ -34,11 +35,14 @@
         // runs after the initial onMount
         box.setFocus = setFocus;
         box.refreshComponent = refresh;
-        // Evaluated and re-evaluated when the box changes.
-        refresh('Refresh Layout box changed ' + box?.id);
+        // Use untrack to avoid triggering state_unsafe_mutation error in Svelte 5
+        untrack(() => {
+            refreshInternal('Refresh Layout box changed ' + box?.id);
+        });
     });
 
-    const refresh = (why?: string): void => {
+    /** Internal refresh function. Should be wrapped in untrack() when called from effects. */
+    const refreshInternal = (why?: string): void => {
         LOGGER.log('REFRESH LayoutComponent (' + why + ')' + box?.node?.freLanguageConcept());
         id = notNullOrUndefined(box) ? componentId(box) : 'layout-for-unknown-box';
         children = [...box.children];
@@ -52,6 +56,14 @@
             errorCls = '';
             errMess = [];
         }
+    };
+
+    /** External refresh function exposed to box.refreshComponent.
+     *  Defers state mutations to after the current reactive cycle. */
+    const refresh = (why?: string): void => {
+        tick().then(() => {
+            refreshInternal(why);
+        });
     };
 </script>
 


### PR DESCRIPTION
## Summary
- In Svelte 5, mutating state during an effect triggers a state_unsafe_mutation error
- This splits refresh() into refreshInternal() (wrapped in untrack()) and refresh() (deferred via tick())

## Changes
- `LayoutComponent.svelte`: Add untrack/tick imports and split refresh function