### PR TITLE
fix: add EvaluateFunction type cast for strict TypeScript

### DIFF
--- a/packages/meta/src/interpretergen/generator/templates/InterpreterBaseTemplate.ts
+++ b/packages/meta/src/interpretergen/generator/templates/InterpreterBaseTemplate.ts
@@ -67,7 +67,7 @@ export class InterpreterBaseTemplate {
         const interpreter = Names.interpreterClassname(language);
         return `
         // TEMPLATE: InterpreterBaseTemplate.interpreterInit(...)
-        import { type IMainInterpreter } from "@freon4dsl/core";
+        import { type IMainInterpreter, type EvaluateFunction } from "@freon4dsl/core";
         import { ${interpreter} } from "${relativePath}/${customsFolder}/${interpreter}.js";
 
         /**
@@ -78,9 +78,9 @@ export class InterpreterBaseTemplate {
 
             ${interpreterDef.conceptsToEvaluate
                 .map((c) => {
-                    return `main.registerFunction("${Names.classifier(c)}", interpreter.eval${Names.classifier(c)});`;
+                    return `main.registerFunction("${Names.classifier(c)}", interpreter.eval${Names.classifier(c)} as EvaluateFunction);`;
                 })
-                .join("\n")} // DONE
+                .join("\n")}
 
         }`;
     }


### PR DESCRIPTION
## Summary
- The generated interpreter init code was missing a type annotation, causing errors under strict TypeScript settings
- Also removes a stray "// DONE" comment from the generated output

## Changes
- `InterpreterBaseTemplate.ts`: Add EvaluateFunction import and type cast to registerFunction calls