### PR TITLE
Re-export FreUndoManager and FreUndoStackManager from public API

### DIFF
--- a/packages/core/src/change-manager/internal.ts
+++ b/packages/core/src/change-manager/internal.ts
@@ -1,4 +1,6 @@
 export * from "./AstObserver.js";
 export * from "./FreDelta.js";
 export * from "./AstChanger.js"
+export * from "./FreUndoManager.js"
+export * from "./FreUndoStackManager.js"
 export * from "./ReferenceUpdateManager.js"


### PR DESCRIPTION
## Summary

Re-export `FreUndoManager` and `FreUndoStackManager` from the change-manager module's public API.

## Motivation

After the change-manager refactoring that introduced `AstObserver` and `AstChanger`, `FreUndoManager` and `FreUndoStackManager` are no longer exported from `@freon4dsl/core`. The classes still exist and are used internally (e.g. `AstChanger` imports `FreUndoManager` directly), but they are not reachable through the package's public export chain.

Applications that need undo/redo functionality must be able to:

- Call `FreUndoManager.getInstance()` to access the undo manager
- Call `cleanAllStacks()` when loading or switching models
- Subscribe to undo state changes for UI indicators (undo/redo button enabled state)
- Access `FreUndoStackManager` for advanced undo stack management

Without these exports, the only way to use undo is to import from internal module paths, which is fragile and breaks when the internal structure changes.

## Changes

**`packages/core/src/change-manager/internal.ts`:**
- Added `export * from "./FreUndoManager.js"`
- Added `export * from "./FreUndoStackManager.js"`

This restores the public API surface that existed before the refactoring, with no behavioral changes.