### PR TITLE
Fix keyboard navigation through external property wrapper boxes

### DIFF
--- a/packages/core/src/editor/boxes/externalBoxes/AbstractPropertyWrapperBox.ts
+++ b/packages/core/src/editor/boxes/externalBoxes/AbstractPropertyWrapperBox.ts
@@ -4,31 +4,49 @@ import { FreLanguage } from "../../../language/index.js";
 import type { Box } from "../Box.js";
 
 export abstract class AbstractPropertyWrapperBox extends AbstractExternalBox {
-    // the following two are inherit from Box
-    // propertyName: string;       // the name of the property, if any, in 'element' which this box projects
-    // propertyIndex: number;      // the index within the property, if appropriate
-    propertyClassifierName: string = "unknown-type"; // the name of the type of the elements in the list
-    private _childBox: Box; // todo mix this with .children from Box
+  // the following two are inherit from Box
+  // propertyName: string;       // the name of the property, if any, in 'element' which this box projects
+  // propertyIndex: number;      // the index within the property, if appropriate
+  propertyClassifierName: string = "unknown-type"; // the name of the type of the elements in the list
+  private _childBox: Box; // todo mix this with .children from Box
 
-    constructor(externalComponentName: string, node: FreNode, role: string, propertyName: string, childBox: Box) {
-        super(externalComponentName, node, role);
-        this.propertyName = propertyName;
-        this._childBox = childBox;
-        this.propertyClassifierName = FreLanguage.getInstance().classifierProperty(
-            node.freLanguageConcept(),
-            propertyName,
-        )?.type;
-    }
+  constructor(
+    externalComponentName: string,
+    node: FreNode,
+    role: string,
+    propertyName: string,
+    childBox: Box,
+  ) {
+    super(externalComponentName, node, role);
+    this.propertyName = propertyName;
+    this._childBox = childBox;
+    this.propertyClassifierName = FreLanguage.getInstance().classifierProperty(
+      node.freLanguageConcept(),
+      propertyName,
+    )?.type;
+  }
 
-    getPropertyName(): string {
-        return this.propertyName;
-    }
+  getPropertyName(): string {
+    return this.propertyName;
+  }
 
-    get childBox(): Box {
-        return this._childBox;
-    }
+  get childBox(): Box {
+    return this._childBox;
+  }
 
-    get children(): ReadonlyArray<Box> {
-        return [this._childBox] as ReadonlyArray<Box>;
-    }
+  get children(): ReadonlyArray<Box> {
+    return [this._childBox] as ReadonlyArray<Box>;
+  }
+
+  get firstLeaf(): Box | null {
+    if (!this.isVisible) return null;
+    if (this.selectable) return this;
+    return this._childBox?.firstLeaf ?? null;
+  }
+
+  get lastLeaf(): Box | null {
+    if (!this.isVisible) return null;
+    if (this.selectable) return this;
+    return this._childBox?.lastLeaf ?? null;
+  }
 }


### PR DESCRIPTION
## Summary

Add `firstLeaf` and `lastLeaf` overrides to `AbstractPropertyWrapperBox` so that keyboard navigation correctly traverses into external wrapper components.

## Problem

When navigating through the box tree with arrow keys or tab, external property wrapper boxes (subclasses of `AbstractPropertyWrapperBox`) are skipped entirely. The cursor jumps from the element before the wrapper to the element after it, making the wrapped content unreachable via keyboard.

This happens because `AbstractPropertyWrapperBox` does not override `firstLeaf` or `lastLeaf`. The default implementation in `Box` walks the `children` array, but `AbstractPropertyWrapperBox` stores its navigable content in a private `_childBox` field. The generic traversal does not find a selectable leaf inside the wrapper, so navigation skips past it.

This affects all external wrapper box types:
- `StringWrapperBox`
- `PartWrapperBox`
- `FragmentWrapperBox`
- `NumberWrapperBox`
- `RefWrapperBox`
- `PartListWrapperBox`
- `RefListWrapperBox`

## Changes

**`packages/core/src/editor/boxes/externalBoxes/AbstractPropertyWrapperBox.ts`:**
- Added `get firstLeaf()` — returns `this` if selectable, otherwise delegates to `_childBox.firstLeaf`
- Added `get lastLeaf()` — returns `this` if selectable, otherwise delegates to `_childBox.lastLeaf`
- Both respect visibility checks consistent with other box types

## Behavior

- Keyboard navigation (arrow keys, tab) now enters external wrapper components instead of skipping them
- If the wrapper itself is selectable, it is returned as the leaf
- If not, navigation continues into the child box tree
- No change to mouse interaction or other behavior