### PR TITLE
Remove duplicate IModelManager export in storage index

### DIFF
--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,6 +1,5 @@
 export * from "./IModelManager.js"
 export * from "./ModelManager.js";
-export * from "./IModelManager.js"
 export * from "./serializer/index.js";
 export * from "./server/index.js";
 export * from "./lionweb-delta/index.js"


### PR DESCRIPTION
## Summary

Remove the duplicate `export * from "./IModelManager.js"` line in `packages/core/src/storage/index.ts`.

## Problem

`IModelManager.js` is exported twice (lines 1 and 3 of `storage/index.ts`). While this is harmless in isolation, it causes a TypeScript TS2308 error ("Module has already exported a member named ...") when any other module in the re-export chain also exports a symbol with the same name as one in `IModelManager`. The duplicate makes the origin of the export ambiguous.

## Changes

**`packages/core/src/storage/index.ts`:**
- Removed the second `export * from "./IModelManager.js"` on line 3

One-line fix, no behavioral change.