### PR TITLE
Support initializer parameters for generated list boxes

### DIFF
--- a/packages/meta/src/editordef/generator/templates/boxproviderhelpers/ListPropertyBoxHelper.ts
+++ b/packages/meta/src/editordef/generator/templates/boxproviderhelpers/ListPropertyBoxHelper.ts
@@ -16,20 +16,51 @@ export class ListPropertyBoxHelper {
         this._myTemplate = myTemplate;
     }
 
+    /**
+     * Build an initializer string for ListBox properties that can be set from .edit file params.
+     * Currently supports: canDragAndDrop (defaults to true if not specified)
+     * @param item The property projection item that may contain externalInfo with params
+     * @returns An initializer string like ", { canDragAndDrop: false }" or empty string
+     */
+    private buildListInitializer(item: FreEditPropertyProjection): string {
+        const params = item.externalInfo?.params;
+        if (!params || params.length === 0) {
+            return "";
+        }
+        
+        // Extract list-specific params that should be passed to the ListBox initializer
+        const canDragAndDropParam = params.find(p => p.key === "canDragAndDrop");
+        
+        // Build initializer object properties
+        const initProps: string[] = [];
+        if (canDragAndDropParam) {
+            const value = canDragAndDropParam.value.toLowerCase() === "true";
+            initProps.push(`canDragAndDrop: ${value}`);
+        }
+        
+        if (initProps.length === 0) {
+            return "";
+        }
+        
+        return `, { ${initProps.join(", ")} }`;
+    }
+
     public generateReferenceAsList(
         // @ts-ignore
         language: FreMetaLanguage,
         listJoin: FreEditListInfo,
         reference: FreMetaConceptProperty,
-        element: string
+        element: string,
+        item?: FreEditPropertyProjection
     ): string {
         this._myTemplate.imports.core.add("BoxUtil");
         this._myTemplate.imports.root.add(Names.LanguageEnvironment);
         const joinEntry = this.getJoinEntry(listJoin);
+        const initializer = item ? this.buildListInitializer(item) : "";
         if (listJoin.direction === FreEditProjectionDirection.Vertical) {
-            return `BoxUtil.verticalReferenceListBox(${element}, "${reference.name}", ${Names.LanguageEnvironment}.getInstance().scoper, ${joinEntry})`;
+            return `BoxUtil.verticalReferenceListBox(${element}, "${reference.name}", ${Names.LanguageEnvironment}.getInstance().scoper, ${joinEntry}${initializer})`;
         } // else
-        return `BoxUtil.horizontalReferenceListBox(${element}, "${reference.name}", ${Names.LanguageEnvironment}.getInstance().scoper, ${joinEntry})`;
+        return `BoxUtil.horizontalReferenceListBox(${element}, "${reference.name}", ${Names.LanguageEnvironment}.getInstance().scoper, ${joinEntry}${initializer})`;
     }
 
     public getJoinEntry(listJoin: FreEditListInfo): string {
@@ -57,10 +88,11 @@ export class ListPropertyBoxHelper {
         if (!!item.listInfo && !!item.property) {
             this._myTemplate.imports.core.add("BoxUtil");
             const joinEntry: string = this.getJoinEntry(item.listInfo);
+            const initializer: string = this.buildListInitializer(item);
             if (item.listInfo.direction === FreEditProjectionDirection.Vertical) {
-                return `BoxUtil.verticalPartListBox(${elementVarName}, ${elementVarName}.${propertyConcept.name}, "${propertyConcept.name}", ${joinEntry}, this.mainHandler)`;
+                return `BoxUtil.verticalPartListBox(${elementVarName}, ${elementVarName}.${propertyConcept.name}, "${propertyConcept.name}", ${joinEntry}, this.mainHandler${initializer})`;
             } // else
-            return `BoxUtil.horizontalPartListBox(${elementVarName}, ${elementVarName}.${propertyConcept.name}, "${propertyConcept.name}", ${joinEntry}, this.mainHandler)`;
+            return `BoxUtil.horizontalPartListBox(${elementVarName}, ${elementVarName}.${propertyConcept.name}, "${propertyConcept.name}", ${joinEntry}, this.mainHandler${initializer})`;
         } else {
             return "";
         }


### PR DESCRIPTION
## Summary

Add support for passing initializer parameters from `.edit` file definitions through to generated `ListBox` instances, starting with `canDragAndDrop`.

## Motivation

List boxes are currently generated with hardcoded behavior — for example, drag-and-drop reordering is always enabled. There is no way for a language designer to control these properties from the `.edit` file.

This is a problem for lists where reordering does not make semantic sense (e.g. a computed/derived list, a log of immutable events, or a list with a fixed ordering constraint). Enabling drag-and-drop on such lists is confusing to end users and can corrupt model state if items are reordered.

## Changes

**`packages/meta/src/editordef/generator/templates/boxproviderhelpers/ListPropertyBoxHelper.ts`:**

- Added `buildListInitializer()` method that reads params from the projection definition and builds an initializer object string
- Modified `generateReferenceAsList()` to accept an optional `item` parameter and append the initializer
- Modified `generatePartAsList()` to append the initializer to generated part list box calls

### Supported parameters

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `canDragAndDrop` | boolean | true | Controls whether list items can be reordered by dragging |

### Example usage in .edit file

```
SomeList {
    [vertical, canDragAndDrop=false] self.items
}
```

This generates:
```typescript
BoxUtil.verticalPartListBox(node, node.items, "items", joinEntry, this.mainHandler, { canDragAndDrop: false })
```

### Backwards compatibility

The initializer is only appended when params are present. Existing `.edit` files that do not specify params generate identical code as before — no migration required.

## Future extensions

The `buildListInitializer` pattern is designed to be extended with additional list properties as needed (e.g. `maxItems`, `minItems`, `showIndex`). Each new parameter requires adding a case to the method and ensuring the corresponding `ListBox` constructor accepts it.