### PR TITLE
Allow external components to replace limited concept boxes

### DIFF
--- a/packages/meta/src/editordef/generator/templates/boxproviderhelpers/ExternalBoxesHelper.ts
+++ b/packages/meta/src/editordef/generator/templates/boxproviderhelpers/ExternalBoxesHelper.ts
@@ -114,7 +114,7 @@ export class ExternalBoxesHelper {
                     )`;
     }
 
-    private replaceSingleByExternal(
+    public replaceSingleByExternal(
         item: FreEditPropertyProjection,
         property: FreMetaConceptProperty,
         elementVarName: string,

--- a/packages/meta/src/editordef/generator/templates/boxproviderhelpers/ItemBoxHelper.ts
+++ b/packages/meta/src/editordef/generator/templates/boxproviderhelpers/ItemBoxHelper.ts
@@ -183,13 +183,19 @@ export class ItemBoxHelper {
     ): string {
         let result: string = "";
         if (property.type instanceof FreMetaLimitedConcept) {
-            result += this._myLimitedHelper.generateLimited(
-                property,
-                elementVarName,
-                language,
-                item.listInfo,
-                item.displayType,
-            );
+            if (!!item.externalInfo && !!item.externalInfo.replaceBy && item.externalInfo.replaceBy.length > 0) {
+                // Use external component to replace the limited concept box
+                result += this._myExternalHelper.replaceSingleByExternal(item, property, elementVarName);
+            } else {
+                // Use standard limited concept box
+                result += this._myLimitedHelper.generateLimited(
+                    property,
+                    elementVarName,
+                    language,
+                    item.listInfo,
+                    item.displayType,
+                );
+            }
         } else if (property.isList) {
             let innerResult: string = "";
             if (!!item.listInfo && item.listInfo.isTable) {


### PR DESCRIPTION
## Summary
- `ItemBoxHelper.generateRefProperty` now consults `item.externalInfo.replaceBy` when the property type is a `FreMetaLimitedConcept`, matching the behavior already implemented for non-limited single / list references.
- `ExternalBoxesHelper.replaceSingleByExternal` is changed from `private` to `public` so the limited-concept branch can call it.

## Motivation
A `.edit` rule like `${someLimitedProp replace=MyCustomComponent placeholder="..."}` is silently ignored today — the generator always emits `BoxUtil.limitedBox(..., LimitedDisplay.SELECT, ...)` for single-value limited concept properties, regardless of `replace=`. Non-limited references already honor `replace=`, so the current behavior is asymmetric and surprising to language authors who want to substitute a richer UI (autocomplete, filterable list, etc.) for the built-in dropdown.

With this change, limited concept properties follow the same rule as other single-value references: if `externalInfo.replaceBy` is set, a `PartReplacerBox` / `RefReplacerBox` is emitted referencing the custom component; otherwise the existing `BoxUtil.limitedBox(...)` call is generated unchanged.

## Behavior
- **No `replace=`**: identical output to today (`BoxUtil.limitedBox(...)`).
- **With `replace=X`**: emits `BoxUtil.refReplacerBox(..., "X", ...)` via the existing `replaceSingleByExternal` helper, consistent with non-limited reference properties.

## Test plan
- [x] `npm run build` in `packages/meta` succeeds
- [ ] Generator snapshot: existing languages without `replace=` on limited properties produce byte-identical output
- [ ] New case: a language with `replace=X` on a limited property produces a `refReplacerBox` call instead of a `limitedBox` call