### PR TITLE
fix(editor): guard null editor.selectedBox in FreCreatePartAction pos…

### DIFF
--- a/packages/core/src/editor/actions/FreCreatePartAction.ts
+++ b/packages/core/src/editor/actions/FreCreatePartAction.ts
@@ -85,15 +85,19 @@ export class FreCreatePartAction extends FreAction {
         return function () {
             // editor.selectElement(newElement);
             // tslint:disable-next-line:max-line-length
+            // NB: editor.selectedBox may be null here. It is only set once a box has been
+            // selected (e.g. via keyboard/click). When executeOption is invoked without a prior
+            // selection, this post-action runs with selectedBox === null, so guard the log to
+            // avoid throwing "Cannot read properties of null (reading 'node')".
             ACTION_LOGGER.log(
                 "CreatePartCommand: newElement:" +
                 newNode.freId() +
                 " " +
                 newNode.freLanguageConcept() +
                 ", selected element: " +
-                editor.selectedBox.node.freId() +
+                (editor.selectedBox?.node?.freId() ?? "<none>") +
                 " of kind " +
-                editor.selectedBox.kind,
+                (editor.selectedBox?.kind ?? "<none>"),
             );
             editor.selectFirstEditableChildBox(newNode, true);
         };


### PR DESCRIPTION
…t-action

FreCreatePartAction.execute returns a post-action closure that logs `editor.selectedBox.node.freId()` and `editor.selectedBox.kind`. The string arguments to ACTION_LOGGER.log are evaluated eagerly (before the logger decides whether to emit), so the dereference runs even when logging is disabled.

`editor.selectedBox` is null-initialized in FreEditor and is only set once a box has been selected (keyboard/click). When a consumer invokes ActionBox.executeOption without first establishing a selection — e.g. a custom component that creates a part programmatically — this post-action throws "Cannot read properties of null (reading 'node')", which aborts the action's follow-up (selectFirstEditableChildBox) and leaves the editor in a bad state.

Guard the dereference with optional chaining and a "<none>" fallback. No behavior change when a selection exists; the crash is avoided when it does not.