### PR TITLE
fix(meta): generate correct typer/stdlib barrel index files

### DIFF
--- a/packages/meta/src/languagedef/generator/LanguageGenerator.ts
+++ b/packages/meta/src/languagedef/generator/LanguageGenerator.ts
@@ -243,11 +243,11 @@ export class LanguageGenerator {
         {
             LOGGER.log(`Generating stdlib index: ${this.stdlibFolder}/index.ts`);
             const indexFile = FileUtil.pretty(
-                stdlibTemplate.generateIndex(),
+                stdlibTemplate.generateIndex(language),
                 "Stdlib Index Class",
                 generationStatus,
             );
-            FileUtil.generateManualFile(`${this.stdlibFolder}/index.ts`, indexFile, "Stdlib Index Class");
+            fs.writeFileSync(`${this.stdlibFolder}/index.ts`, indexFile);
         }
 
         LOGGER.log(`Generating command line: ${this.commandlineFolder}/FreonCommandLine.ts`);

--- a/packages/meta/src/languagedef/generator/templates/StdlibTemplate.ts
+++ b/packages/meta/src/languagedef/generator/templates/StdlibTemplate.ts
@@ -126,9 +126,9 @@ export class StdlibTemplate {
             });
     }
 
-    generateIndex() {
+    generateIndex(language: FreMetaLanguage) {
         return `
-        export * from "./index.js";
+        export * from "./${Names.stdlib(language)}.js";
         `;
     }
 }

--- a/packages/meta/src/scoperdef/generator/templates/ScoperTemplate.ts
+++ b/packages/meta/src/scoperdef/generator/templates/ScoperTemplate.ts
@@ -18,12 +18,6 @@ export class ScoperTemplate {
         `;
     }
 
-    generateIndex(): string {
-        return `
-        export * from "./index.js";
-        `;
-    }
-
     generateScoper(language: FreMetaLanguage, scopedef: ScopeDef, relativePath: string): string {
         this.alternativeNamespaceText = "";
         this.importedNamespaceText = "";

--- a/packages/meta/src/typerdef/generator/FreonTyperGenerator.ts
+++ b/packages/meta/src/typerdef/generator/FreonTyperGenerator.ts
@@ -128,10 +128,6 @@ export class FreonTyperGenerator {
             "Custom TyperPart",
         );
 
-        LOGGER.log(`Generating typer index: ${this.typerFolder}/index.ts`);
-        const typerIndexFile = FileUtil.pretty(typer.generateIndex(this.language), "Typer Index", generationStatus);
-        FileUtil.generateManualFile(`${this.typerFolder}/index.ts`, typerIndexFile, "Typer Index");
-
         if (generationStatus.numberOfErrors > 0) {
             LOGGER.error(`Generated typer with ${generationStatus.numberOfErrors} errors.`);
         } else {

--- a/packages/meta/src/typerdef/generator/templates/FreTyperTemplate.ts
+++ b/packages/meta/src/typerdef/generator/templates/FreTyperTemplate.ts
@@ -17,14 +17,4 @@ export class FreTyperTemplate {
         export * from "./${Names.typerDef(language)}.js";
         `;
     }
-
-    generateIndex(language: FreMetaLanguage): string {
-        if (language === undefined || language === null) {
-            LOG2USER.error("Could not create index, because language was not set.");
-            return "";
-        }
-        return `
-        export * from "./index.js";
-        `;
-    }
 }

--- a/packages/meta/src/validatordef/generator/templates/ValidatorTemplate.ts
+++ b/packages/meta/src/validatordef/generator/templates/ValidatorTemplate.ts
@@ -135,10 +135,4 @@ export class ValidatorTemplate {
             errorList: ${Names.FreError}[] = [];
         }`;
     }
-
-    generateIndex() {
-        return `
-        export * from "./index.js";
-        `;
-    }
 }


### PR DESCRIPTION
## Problem

The generator emits **self-referential** barrel `index.ts` files for the `typer/` and `stdlib/` folders:

```ts
// <lang>/typer/index.ts  and  <lang>/stdlib/index.ts
export * from "./index.js";   // re-exports from itself → re-exports nothing
```

instead of re-exporting the actual generated definition files. When a consumer imports a named export from such a barrel (e.g. `import { initializeTypers } from "../typer/index.js"` in the generated `…ModelEnvironment.ts`), Node throws at module load:

```
SyntaxError: The requested module '../typer/index.js' does not provide an export named 'initializeTypers'
```

### Why it's intermittent

`FreonTyperGenerator` writes `typer/index.ts` **twice**:

1. `fs.writeFileSync(typer/index.ts, generateGenIndex())` — the **correct** barrel (`export * from "./<TyperPart>.js"` + `<TyperDef>.js`).
2. `FileUtil.generateManualFile(typer/index.ts, generateIndex())` — the **broken** self-referential barrel.

`generateManualFile` only writes *if the file is absent*. Normally step 1 creates the file and step 2 is a no-op, so everything works. But on a clean/partial regeneration where `typer/index.ts` is absent when step 2 runs, the broken fallback wins — leaving a barrel that re-exports nothing.

For **stdlib** there is only the single broken write path (`StdlibTemplate.generateIndex()` always returns `export * from "./index.js"`), so `stdlib/index.ts` is *always* self-referential — latent only because nothing currently imports a named export from it.

## Fix

- **`StdlibTemplate.generateIndex(language)`** — export the stdlib class via `Names.stdlib(language)` instead of `"./index.js"`, and write it unconditionally (`writeFileSync`) so a stale broken index self-heals on regeneration rather than being preserved by `generateManualFile`.
- **`FreonTyperGenerator`** — drop the redundant `generateManualFile()` second write of `typer/index.ts`. The `generateGenIndex()` write already produces the full, correct barrel.
- **Remove the dead, self-referential `generateIndex()` methods** from the typer, scoper, and validator templates. They have no callers (scoper/validator already use `generateGenIndex()`); they're the same latent trap waiting to be wired up.

## Verification

- `packages/meta` builds clean.
- Full meta test suite passes: **126 passed, 4 skipped**.
- Scoper/validator generation **snapshots are unchanged**, confirming the removed `generateIndex()` methods were genuinely unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)